### PR TITLE
feat: add sdk span tracing foundation

### DIFF
--- a/packages/ts/sdk/src/index.ts
+++ b/packages/ts/sdk/src/index.ts
@@ -11,12 +11,14 @@ import type {
 } from "@captar/types";
 import { createId } from "@captar/utils";
 
+import { BudgetExceededError, PolicyViolationError } from "./internal/errors.js";
 import { EventBus } from "./internal/event-bus.js";
 import { HttpBatchExporter, NoopExporter } from "./internal/exporter.js";
 import { OpenAIAdapter } from "./internal/openai-adapter.js";
 import { PolicyEngine } from "./internal/policy-engine.js";
 import { PricingRegistry } from "./internal/pricing-registry.js";
 import { RuntimeSession } from "./internal/session.js";
+import { createSpanSnapshot, updateSpanSnapshot } from "./internal/span.js";
 import { createTrackedTool } from "./internal/tools.js";
 
 export * from "@captar/types";
@@ -91,6 +93,14 @@ async function fetchControlPlanePolicy(
   return payload.hook.policy;
 }
 
+function isBlockedExecutionError(error: unknown): boolean {
+  return error instanceof PolicyViolationError || error instanceof BudgetExceededError;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "unknown error";
+}
+
 export function createCaptar(options: CaptarOptions) {
   const bus = new EventBus();
   const exporter = createExporter(options);
@@ -154,109 +164,295 @@ export function createCaptar(options: CaptarOptions) {
             policy?.call?.timeoutMs,
           );
           const estimate = await adapter.estimate(request);
-          session.markRequest(false);
-          await session.emit("request.started", {
-            provider: "openai",
-            model: estimate.model,
-            requestId: createId("req"),
-            namespace,
-            methodName,
-            request,
+          const requestId = createId("req");
+          const requestSpan = createSpanSnapshot({
+            parentId: session.trace.spanId,
+            name: `${namespace}.${methodName}`,
+            kind: "request",
+            attributes: {
+              provider: "openai",
+              model: estimate.model,
+              namespace,
+              methodName,
+              requestId,
+              stream: Boolean(request.stream),
+            },
           });
+          let reservedUsd = 0;
+          session.markRequest(false);
+          await session.emit(
+            "request.started",
+            {
+              provider: "openai",
+              model: estimate.model,
+              requestId,
+              namespace,
+              methodName,
+              request,
+            },
+            {
+              spanId: requestSpan.id,
+              parentSpanId: requestSpan.parentId,
+              span: requestSpan,
+            },
+          );
 
           try {
             policyEngine.evaluateCall(request, policy, estimate.estimatedCostUsd);
-          } catch (error) {
-            session.markRequest(true);
-            await session.emit("request.blocked", {
-              reason: error instanceof Error ? error.message : "blocked",
-              provider: "openai",
-              model: estimate.model,
+            await session.emit(
+              "request.allowed",
+              {
+                provider: "openai",
+                model: estimate.model,
+                estimatedCostUsd: estimate.estimatedCostUsd,
+              },
+              {
+                spanId: requestSpan.id,
+                parentSpanId: requestSpan.parentId,
+                span: requestSpan,
+              },
+            );
+
+            reservedUsd = session.reserve(estimate.estimatedCostUsd, {
+              label: methodName,
             });
-            throw error;
-          }
+            await session.emit(
+              "estimate.reserved",
+              {
+                provider: "openai",
+                model: estimate.model,
+                reservedUsd,
+              },
+              {
+                spanId: requestSpan.id,
+                parentSpanId: requestSpan.parentId,
+                span: requestSpan,
+              },
+            );
 
-          await session.emit("request.allowed", {
-            provider: "openai",
-            model: estimate.model,
-            estimatedCostUsd: estimate.estimatedCostUsd,
-          });
+            const response = await adapter.execute(request);
 
-          const reservedUsd = session.reserve(estimate.estimatedCostUsd, {
-            label: methodName,
-          });
-          await session.emit("estimate.reserved", {
-            provider: "openai",
-            model: estimate.model,
-            reservedUsd,
-          });
+            if (
+              request.stream &&
+              typeof response === "object" &&
+              response !== null &&
+              Symbol.asyncIterator in response
+            ) {
+              const chunks: Array<Partial<Record<string, number>>> = [];
+              const stream = response as unknown as AsyncIterable<Record<string, unknown>>;
+              const wrapped = {
+                async *[Symbol.asyncIterator]() {
+                  try {
+                    for await (const chunk of stream) {
+                      const usage = chunk.usage;
+                      if (usage && typeof usage === "object") {
+                        chunks.push(usage as Partial<Record<string, number>>);
+                      }
+                      yield chunk;
+                    }
+                  } catch (error) {
+                    const endedAt = new Date().toISOString();
+                    const failedSpan = updateSpanSnapshot(requestSpan, {
+                      status: "failed",
+                      endedAt,
+                      attributes: {
+                        error: errorMessage(error),
+                      },
+                    });
 
-          const response = await adapter.execute(request);
+                    if (reservedUsd > 0) {
+                      const reconciliation = session.commit(reservedUsd, 0);
+                      reservedUsd = 0;
+                      await session.emit(
+                        "spend.committed",
+                        {
+                          provider: "openai",
+                          model: estimate.model,
+                          actualCostUsd: reconciliation.actualUsd,
+                          releasedUsd: reconciliation.releasedUsd,
+                        },
+                        {
+                          spanId: requestSpan.id,
+                          parentSpanId: requestSpan.parentId,
+                          span: failedSpan,
+                        },
+                      );
+                    }
 
-          if (
-            request.stream &&
-            typeof response === "object" &&
-            response !== null &&
-            Symbol.asyncIterator in response
-          ) {
-            const chunks: Array<Partial<Record<string, number>>> = [];
-            const stream = response as unknown as AsyncIterable<Record<string, unknown>>;
-            const wrapped = {
-              async *[Symbol.asyncIterator]() {
-                for await (const chunk of stream) {
-                  const usage = chunk.usage;
-                  if (usage && typeof usage === "object") {
-                    chunks.push(usage as Partial<Record<string, number>>);
+                    await session.emit(
+                      "request.failed",
+                      {
+                        reason: errorMessage(error),
+                        provider: "openai",
+                        model: estimate.model,
+                      },
+                      {
+                        spanId: requestSpan.id,
+                        parentSpanId: requestSpan.parentId,
+                        span: failedSpan,
+                      },
+                    );
+                    throw error;
                   }
-                  yield chunk;
-                }
-                const actualUsage = adapter.extractStreamUsage(
-                  estimate.model,
-                  chunks,
-                  estimate.estimatedCostUsd,
-                );
-                const reconciliation = session.commit(
-                  reservedUsd,
-                  actualUsage.costUsd,
-                );
-                await session.emit(
-                  "provider.response",
-                  {
-                    ...actualUsage,
-                    response,
-                  } as unknown as Record<string, unknown>,
-                );
-                await session.emit("spend.committed", {
+
+                  const endedAt = new Date().toISOString();
+                  const actualUsage = adapter.extractStreamUsage(
+                    estimate.model,
+                    chunks,
+                    estimate.estimatedCostUsd,
+                  );
+                  const completedSpan = updateSpanSnapshot(requestSpan, {
+                    status: "completed",
+                    endedAt,
+                    attributes: {
+                      model: actualUsage.model,
+                      inputTokens: actualUsage.inputTokens ?? null,
+                      outputTokens: actualUsage.outputTokens ?? null,
+                      cachedInputTokens: actualUsage.cachedInputTokens ?? null,
+                      costUsd: actualUsage.costUsd,
+                    },
+                  });
+                  const reconciliation = session.commit(
+                    reservedUsd,
+                    actualUsage.costUsd,
+                  );
+                  reservedUsd = 0;
+                  await session.emit(
+                    "provider.response",
+                    {
+                      ...actualUsage,
+                      response,
+                    } as unknown as Record<string, unknown>,
+                    {
+                      spanId: requestSpan.id,
+                      parentSpanId: requestSpan.parentId,
+                      span: completedSpan,
+                    },
+                  );
+                  await session.emit(
+                    "spend.committed",
+                    {
+                      provider: "openai",
+                      model: actualUsage.model,
+                      actualCostUsd: reconciliation.actualUsd,
+                      releasedUsd: reconciliation.releasedUsd,
+                    },
+                    {
+                      spanId: requestSpan.id,
+                      parentSpanId: requestSpan.parentId,
+                      span: completedSpan,
+                    },
+                  );
+                },
+              };
+
+              return wrapped;
+            }
+
+            const endedAt = new Date().toISOString();
+            const actualUsage = adapter.extractUsage(
+              response as Record<string, unknown>,
+              estimate.estimatedCostUsd,
+            );
+            const completedSpan = updateSpanSnapshot(requestSpan, {
+              status: "completed",
+              endedAt,
+              attributes: {
+                model: actualUsage.model,
+                inputTokens: actualUsage.inputTokens ?? null,
+                outputTokens: actualUsage.outputTokens ?? null,
+                cachedInputTokens: actualUsage.cachedInputTokens ?? null,
+                costUsd: actualUsage.costUsd,
+              },
+            });
+            const reconciliation = session.commit(reservedUsd, actualUsage.costUsd);
+            reservedUsd = 0;
+            await session.emit(
+              "provider.response",
+              {
+                ...actualUsage,
+                response,
+              } as unknown as Record<string, unknown>,
+              {
+                spanId: requestSpan.id,
+                parentSpanId: requestSpan.parentId,
+                span: completedSpan,
+              },
+            );
+            await session.emit(
+              "spend.committed",
+              {
+                provider: "openai",
+                model: actualUsage.model,
+                actualCostUsd: reconciliation.actualUsd,
+                releasedUsd: reconciliation.releasedUsd,
+              },
+              {
+                spanId: requestSpan.id,
+                parentSpanId: requestSpan.parentId,
+                span: completedSpan,
+              },
+            );
+            return response;
+          } catch (error) {
+            const endedAt = new Date().toISOString();
+            const blocked = isBlockedExecutionError(error);
+            const finalSpan = updateSpanSnapshot(requestSpan, {
+              status: blocked ? "blocked" : "failed",
+              endedAt,
+              attributes: {
+                error: errorMessage(error),
+              },
+            });
+
+            if (reservedUsd > 0) {
+              const reconciliation = session.commit(reservedUsd, 0);
+              reservedUsd = 0;
+              await session.emit(
+                "spend.committed",
+                {
                   provider: "openai",
-                  model: actualUsage.model,
+                  model: estimate.model,
                   actualCostUsd: reconciliation.actualUsd,
                   releasedUsd: reconciliation.releasedUsd,
-                });
+                },
+                {
+                  spanId: requestSpan.id,
+                  parentSpanId: requestSpan.parentId,
+                  span: finalSpan,
+                },
+              );
+            }
+
+            if (blocked) {
+              session.markRequest(true);
+              await session.emit("request.blocked", {
+                reason: error instanceof Error ? error.message : "blocked",
+                provider: "openai",
+                model: estimate.model,
+              }, {
+                spanId: requestSpan.id,
+                parentSpanId: requestSpan.parentId,
+                span: finalSpan,
+              });
+              throw error;
+            }
+
+            await session.emit(
+              "request.failed",
+              {
+                reason: errorMessage(error),
+                provider: "openai",
+                model: estimate.model,
               },
-            };
-
-            return wrapped;
+              {
+                spanId: requestSpan.id,
+                parentSpanId: requestSpan.parentId,
+                span: finalSpan,
+              },
+            );
+            throw error;
           }
-
-          const actualUsage = adapter.extractUsage(
-            response as Record<string, unknown>,
-            estimate.estimatedCostUsd,
-          );
-          const reconciliation = session.commit(reservedUsd, actualUsage.costUsd);
-          await session.emit(
-            "provider.response",
-            {
-              ...actualUsage,
-              response,
-            } as unknown as Record<string, unknown>,
-          );
-          await session.emit("spend.committed", {
-            provider: "openai",
-            model: actualUsage.model,
-            actualCostUsd: reconciliation.actualUsd,
-            releasedUsd: reconciliation.releasedUsd,
-          });
-          return response;
         };
       };
 

--- a/packages/ts/sdk/src/internal/session.ts
+++ b/packages/ts/sdk/src/internal/session.ts
@@ -13,8 +13,15 @@ import { createId } from "@captar/utils";
 import type { EventBus } from "./event-bus.js";
 import type { HttpBatchExporter, NoopExporter } from "./exporter.js";
 import { BudgetEngine } from "./budget-engine.js";
+import { createSpanSnapshot, updateSpanSnapshot } from "./span.js";
 
 type ExporterLike = HttpBatchExporter | NoopExporter;
+
+interface EmitOptions {
+  spanId?: string;
+  parentSpanId?: string;
+  span?: CaptarEvent["span"];
+}
 
 export class RuntimeSession implements CaptarSession {
   readonly id = createId("session");
@@ -53,6 +60,17 @@ export class RuntimeSession implements CaptarSession {
     await this.emit("session.started", {
       budget: this.budget,
       policy: this.policy,
+    }, {
+      spanId: this.trace.spanId,
+      span: createSpanSnapshot({
+        id: this.trace.spanId,
+        name: "session",
+        kind: "session",
+        startedAt: this.summary.startedAt,
+        attributes: {
+          sessionId: this.id,
+        },
+      }),
     });
   }
 
@@ -69,10 +87,11 @@ export class RuntimeSession implements CaptarSession {
   }
 
   markRequest(blocked = false): void {
-    this.summary.requestCount += 1;
     if (blocked) {
       this.summary.blockedCount += 1;
+      return;
     }
+    this.summary.requestCount += 1;
   }
 
   markToolCall(): void {
@@ -90,8 +109,16 @@ export class RuntimeSession implements CaptarSession {
   async emit<TData extends Record<string, unknown>>(
     type: CaptarEvent["type"],
     data: TData,
-    parentSpanId?: string,
+    options: EmitOptions | string = {},
   ): Promise<void> {
+    const normalizedOptions =
+      typeof options === "string" ? { parentSpanId: options } : options;
+    const spanId =
+      normalizedOptions.span?.id ??
+      normalizedOptions.spanId ??
+      createId("span");
+    const parentSpanId =
+      normalizedOptions.span?.parentId ?? normalizedOptions.parentSpanId;
     const event: CaptarEvent<TData> = {
       id: createId("evt"),
       type,
@@ -99,9 +126,16 @@ export class RuntimeSession implements CaptarSession {
       sessionId: this.id,
       trace: {
         traceId: this.trace.traceId,
-        spanId: createId("span"),
+        spanId,
         parentSpanId,
       },
+      span: normalizedOptions.span
+        ? {
+            ...normalizedOptions.span,
+            id: spanId,
+            parentId: parentSpanId,
+          }
+        : undefined,
       project: this.project,
       metadata: this.metadata,
       data,
@@ -128,7 +162,24 @@ export class RuntimeSession implements CaptarSession {
     await this.emit(
       "session.closed",
       this.getSummary() as unknown as Record<string, unknown>,
-      this.trace.spanId,
+      {
+        spanId: this.trace.spanId,
+        span: updateSpanSnapshot(
+          createSpanSnapshot({
+            id: this.trace.spanId,
+            name: "session",
+            kind: "session",
+            startedAt: this.summary.startedAt,
+            attributes: {
+              sessionId: this.id,
+            },
+          }),
+          {
+            status: "completed",
+            endedAt: this.summary.closedAt,
+          },
+        ),
+      },
     );
     if ("flush" in this.exporter && this.exporter.flush) {
       await this.exporter.flush();

--- a/packages/ts/sdk/src/internal/span.ts
+++ b/packages/ts/sdk/src/internal/span.ts
@@ -1,0 +1,55 @@
+import type {
+  Metadata,
+  TraceSpanKind,
+  TraceSpanSnapshot,
+  TraceSpanStatus,
+} from "@captar/types";
+import { createId } from "@captar/utils";
+
+export function createSpanSnapshot(input: {
+  id?: string;
+  parentId?: string;
+  name: string;
+  kind: TraceSpanKind;
+  status?: TraceSpanStatus;
+  startedAt?: string;
+  endedAt?: string;
+  attributes?: Metadata;
+}): TraceSpanSnapshot {
+  return {
+    id: input.id ?? createId("span"),
+    parentId: input.parentId,
+    name: input.name,
+    kind: input.kind,
+    status: input.status ?? "running",
+    startedAt: input.startedAt ?? new Date().toISOString(),
+    endedAt: input.endedAt,
+    attributes: input.attributes,
+  };
+}
+
+export function updateSpanSnapshot(
+  span: TraceSpanSnapshot,
+  input: {
+    parentId?: string;
+    status?: TraceSpanStatus;
+    endedAt?: string;
+    attributes?: Metadata;
+  },
+): TraceSpanSnapshot {
+  const nextAttributes =
+    span.attributes || input.attributes
+      ? {
+          ...(span.attributes ?? {}),
+          ...(input.attributes ?? {}),
+        }
+      : undefined;
+
+  return {
+    ...span,
+    parentId: input.parentId ?? span.parentId,
+    status: input.status ?? span.status,
+    endedAt: input.endedAt ?? span.endedAt,
+    attributes: nextAttributes,
+  };
+}

--- a/packages/ts/sdk/src/internal/telemetry.ts
+++ b/packages/ts/sdk/src/internal/telemetry.ts
@@ -11,11 +11,17 @@ export function eventToSpanRecord(event: CaptarEvent): OTelSpanRecord {
   return {
     traceId: event.trace.traceId,
     spanId: event.trace.spanId,
-    name: event.type,
+    name: event.span?.name ?? event.type,
     attributes: {
       sessionId: event.sessionId,
       project: event.project ?? "unknown",
       eventType: event.type,
+      ...(event.span
+        ? {
+            spanKind: event.span.kind,
+            spanStatus: event.span.status,
+          }
+        : {}),
     },
   };
 }

--- a/packages/ts/sdk/src/internal/tools.ts
+++ b/packages/ts/sdk/src/internal/tools.ts
@@ -2,6 +2,7 @@ import type { ToolHandle, TrackToolOptions } from "@captar/types";
 
 import { ToolApprovalRequiredError } from "./errors.js";
 import type { RuntimeSession } from "./session.js";
+import { createSpanSnapshot, updateSpanSnapshot } from "./span.js";
 import type { PolicyEngine } from "./policy-engine.js";
 
 export function createTrackedTool<TArgs, TResult>(
@@ -13,11 +14,43 @@ export function createTrackedTool<TArgs, TResult>(
 
   return {
     async run(work: () => Promise<TResult>): Promise<TResult> {
-      policyEngine.evaluateTool(name, {
+      const toolSpan = createSpanSnapshot({
+        parentId: session.trace.spanId,
+        name,
+        kind: "tool",
+        attributes: {
+          toolName: name,
+        },
+      });
+      const toolPolicy = {
         ...session.policy?.tool,
         ...options.policy,
-      });
-      session.markToolCall();
+      };
+
+      try {
+        policyEngine.evaluateTool(name, toolPolicy);
+      } catch (error) {
+        const blockedSpan = updateSpanSnapshot(toolSpan, {
+          status: "blocked",
+          endedAt: new Date().toISOString(),
+          attributes: {
+            reason: error instanceof Error ? error.message : "blocked",
+          },
+        });
+        await session.emit(
+          "tool.blocked",
+          {
+            name,
+            reason: error instanceof Error ? error.message : "blocked",
+          },
+          {
+            spanId: toolSpan.id,
+            parentSpanId: toolSpan.parentId,
+            span: blockedSpan,
+          },
+        );
+        throw error;
+      }
 
       const requiresApproval =
         options.policy?.requireApprovalFor?.includes(name) ||
@@ -34,11 +67,32 @@ export function createTrackedTool<TArgs, TResult>(
             : options.approval;
 
         if (!approved) {
+          const blockedSpan = updateSpanSnapshot(toolSpan, {
+            status: "blocked",
+            endedAt: new Date().toISOString(),
+            attributes: {
+              reason: `Tool "${name}" requires explicit approval.`,
+            },
+          });
+          await session.emit(
+            "tool.blocked",
+            {
+              name,
+              reason: `Tool "${name}" requires explicit approval.`,
+            },
+            {
+              spanId: toolSpan.id,
+              parentSpanId: toolSpan.parentId,
+              span: blockedSpan,
+            },
+          );
           throw new ToolApprovalRequiredError(
             `Tool "${name}" requires explicit approval.`,
           );
         }
       }
+
+      session.markToolCall();
 
       const estimatedCostUsd =
         typeof options.estimate === "function"
@@ -49,32 +103,129 @@ export function createTrackedTool<TArgs, TResult>(
             })
           : options.estimate ?? 0;
 
-      const reservedUsd = session.reserve(estimatedCostUsd, {
-        label: name,
-      });
-      await session.emit("tool.started", {
-        name,
-        estimatedCostUsd,
-      });
+      let reservedUsd = 0;
 
-      const result = await work();
-      const actualCostUsd =
-        typeof options.actual === "function"
-          ? await options.actual({
-              sessionId: session.id,
-              name,
-              result,
-            })
-          : options.actual ?? estimatedCostUsd;
+      try {
+        reservedUsd = session.reserve(estimatedCostUsd, {
+          label: name,
+        });
+        await session.emit(
+          "estimate.reserved",
+          {
+            provider: "tool",
+            model: name,
+            reservedUsd,
+          },
+          {
+            spanId: toolSpan.id,
+            parentSpanId: toolSpan.parentId,
+            span: toolSpan,
+          },
+        );
+        await session.emit(
+          "tool.started",
+          {
+            name,
+            estimatedCostUsd,
+          },
+          {
+            spanId: toolSpan.id,
+            parentSpanId: toolSpan.parentId,
+            span: toolSpan,
+          },
+        );
 
-      const reconciliation = session.commit(reservedUsd, actualCostUsd);
-      await session.emit("tool.completed", {
-        name,
-        actualCostUsd: reconciliation.actualUsd,
-        releasedUsd: reconciliation.releasedUsd,
-      });
+        const result = await work();
+        const actualCostUsd =
+          typeof options.actual === "function"
+            ? await options.actual({
+                sessionId: session.id,
+                name,
+                result,
+              })
+            : options.actual ?? estimatedCostUsd;
 
-      return result;
+        const reconciliation = session.commit(reservedUsd, actualCostUsd);
+        reservedUsd = 0;
+        const completedSpan = updateSpanSnapshot(toolSpan, {
+          status: "completed",
+          endedAt: new Date().toISOString(),
+          attributes: {
+            estimatedCostUsd,
+            actualCostUsd,
+          },
+        });
+        await session.emit(
+          "tool.completed",
+          {
+            name,
+            actualCostUsd: reconciliation.actualUsd,
+            releasedUsd: reconciliation.releasedUsd,
+          },
+          {
+            spanId: toolSpan.id,
+            parentSpanId: toolSpan.parentId,
+            span: completedSpan,
+          },
+        );
+        await session.emit(
+          "spend.committed",
+          {
+            provider: "tool",
+            model: name,
+            actualCostUsd: reconciliation.actualUsd,
+            releasedUsd: reconciliation.releasedUsd,
+          },
+          {
+            spanId: toolSpan.id,
+            parentSpanId: toolSpan.parentId,
+            span: completedSpan,
+          },
+        );
+
+        return result;
+      } catch (error) {
+        const failedSpan = updateSpanSnapshot(toolSpan, {
+          status: "failed",
+          endedAt: new Date().toISOString(),
+          attributes: {
+            error: error instanceof Error ? error.message : "tool failed",
+          },
+        });
+
+        if (reservedUsd > 0) {
+          const reconciliation = session.commit(reservedUsd, 0);
+          reservedUsd = 0;
+          await session.emit(
+            "spend.committed",
+            {
+              provider: "tool",
+              model: name,
+              actualCostUsd: reconciliation.actualUsd,
+              releasedUsd: reconciliation.releasedUsd,
+            },
+            {
+              spanId: toolSpan.id,
+              parentSpanId: toolSpan.parentId,
+              span: failedSpan,
+            },
+          );
+        }
+
+        await session.emit(
+          "tool.failed",
+          {
+            name,
+            reason: error instanceof Error ? error.message : "tool failed",
+          },
+          {
+            spanId: toolSpan.id,
+            parentSpanId: toolSpan.parentId,
+            span: failedSpan,
+          },
+        );
+        throw error;
+      }
     },
   };
 }

--- a/packages/ts/sdk/test/runtime-controller.test.ts
+++ b/packages/ts/sdk/test/runtime-controller.test.ts
@@ -1,14 +1,18 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { createCaptar } from "../src/index.js";
+import { createCaptar, type CaptarEvent } from "../src/index.js";
 
 describe("createCaptar", () => {
-  it("reserves estimated spend and reconciles with actual usage", async () => {
-    const captor = createCaptar({
+  it("emits a stable request span hierarchy and reconciles spend", async () => {
+    const captar = createCaptar({
       project: "support-bot",
     });
+    const events: CaptarEvent[] = [];
+    captar.onEvent((event) => {
+      events.push(event);
+    });
 
-    const session = await captor.startSession({
+    const session = await captar.startSession({
       budget: {
         maxSpendUsd: 2,
         finalizationReserveUsd: 0.2,
@@ -38,7 +42,7 @@ describe("createCaptar", () => {
       },
     };
 
-    const openai = captor.wrapOpenAI(client, { session });
+    const openai = captar.wrapOpenAI(client, { session });
     await openai.responses.create({
       model: "gpt-4.1-mini",
       input: "hello",
@@ -48,14 +52,24 @@ describe("createCaptar", () => {
     const state = session.getState();
     expect(state.committedUsd).toBeGreaterThan(0);
     expect(state.reservedUsd).toBe(0);
+
+    const requestEvents = events.filter((event) => event.span?.kind === "request");
+    expect(requestEvents.length).toBeGreaterThan(0);
+    expect(new Set(requestEvents.map((event) => event.trace.spanId)).size).toBe(1);
+    expect(requestEvents.every((event) => event.trace.parentSpanId === session.trace.spanId)).toBe(true);
+    expect(events.find((event) => event.type === "provider.response")?.span?.status).toBe("completed");
   });
 
   it("blocks disallowed models before making the provider call", async () => {
-    const captor = createCaptar({
+    const captar = createCaptar({
       project: "support-bot",
     });
+    const events: CaptarEvent[] = [];
+    captar.onEvent((event) => {
+      events.push(event);
+    });
 
-    const session = await captor.startSession({
+    const session = await captar.startSession({
       budget: { maxSpendUsd: 1 },
       policy: {
         call: {
@@ -77,7 +91,7 @@ describe("createCaptar", () => {
       },
     };
 
-    const openai = captor.wrapOpenAI(client, { session });
+    const openai = captar.wrapOpenAI(client, { session });
 
     await expect(
       openai.responses.create({
@@ -86,13 +100,57 @@ describe("createCaptar", () => {
       }),
     ).rejects.toThrow(/allow list/);
     expect(client.responses.create).not.toHaveBeenCalled();
+    expect(session.getSummary().blockedCount).toBe(1);
+    expect(events.find((event) => event.type === "request.blocked")?.span?.status).toBe("blocked");
+  });
+
+  it("releases reserved spend and emits request.failed on provider errors", async () => {
+    const captar = createCaptar({
+      project: "support-bot",
+    });
+    const events: CaptarEvent[] = [];
+    captar.onEvent((event) => {
+      events.push(event);
+    });
+    const session = await captar.startSession({
+      budget: { maxSpendUsd: 2, finalizationReserveUsd: 0.1 },
+    });
+
+    const client = {
+      responses: {
+        create: vi.fn(async () => {
+          throw new Error("provider unavailable");
+        }),
+      },
+      chat: {
+        completions: {
+          create: vi.fn(),
+        },
+      },
+    };
+
+    const openai = captar.wrapOpenAI(client, { session });
+
+    await expect(
+      openai.responses.create({
+        model: "gpt-4.1-mini",
+        input: "hello",
+        max_output_tokens: 120,
+      }),
+    ).rejects.toThrow(/provider unavailable/);
+
+    expect(session.getState().reservedUsd).toBe(0);
+    expect(events.find((event) => event.type === "request.failed")?.span?.status).toBe("failed");
+    expect(
+      events.find((event) => event.type === "spend.committed")?.data.releasedUsd,
+    ).toBeGreaterThan(0);
   });
 
   it("tracks tool costs and preserves approval hooks", async () => {
-    const captor = createCaptar({
+    const captar = createCaptar({
       project: "support-bot",
     });
-    const session = await captor.startSession({
+    const session = await captar.startSession({
       budget: { maxSpendUsd: 2 },
       policy: {
         tool: {
@@ -101,7 +159,7 @@ describe("createCaptar", () => {
       },
     });
 
-    const tool = captor.trackTool("zendesk.createComment", {
+    const tool = captar.trackTool("zendesk.createComment", {
       session,
       estimate: 0.25,
       actual: 0.1,
@@ -112,5 +170,38 @@ describe("createCaptar", () => {
     expect(result).toBe("ok");
     expect(session.getSummary().toolCallCount).toBe(1);
     expect(session.getSummary().totalCommittedUsd).toBe(0.1);
+  });
+
+  it("releases reserved tool spend and emits tool.failed on tool errors", async () => {
+    const captar = createCaptar({
+      project: "support-bot",
+    });
+    const events: CaptarEvent[] = [];
+    captar.onEvent((event) => {
+      events.push(event);
+    });
+    const session = await captar.startSession({
+      budget: { maxSpendUsd: 2 },
+    });
+
+    const tool = captar.trackTool("search.docs", {
+      session,
+      estimate: 0.25,
+      actual: 0.1,
+    });
+
+    await expect(
+      tool.run(async () => {
+        throw new Error("tool crashed");
+      }),
+    ).rejects.toThrow(/tool crashed/);
+
+    expect(session.getState().reservedUsd).toBe(0);
+    expect(events.find((event) => event.type === "tool.failed")?.span?.status).toBe("failed");
+    expect(
+      events
+        .filter((event) => event.type === "spend.committed")
+        .some((event) => Number(event.data.releasedUsd ?? 0) > 0),
+    ).toBe(true);
   });
 });

--- a/packages/ts/types/src/index.ts
+++ b/packages/ts/types/src/index.ts
@@ -83,6 +83,21 @@ export interface TraceContext {
   parentSpanId?: string;
 }
 
+export type TraceSpanKind = "session" | "request" | "tool";
+
+export type TraceSpanStatus = "running" | "completed" | "blocked" | "failed";
+
+export interface TraceSpanSnapshot {
+  id: string;
+  parentId?: string;
+  name: string;
+  kind: TraceSpanKind;
+  status: TraceSpanStatus;
+  startedAt: string;
+  endedAt?: string;
+  attributes?: Metadata;
+}
+
 export type GuardrailCategory =
   | "spend"
   | "execution"
@@ -96,11 +111,14 @@ export type CaptarEventType =
   | "request.started"
   | "request.allowed"
   | "request.blocked"
+  | "request.failed"
   | "estimate.reserved"
   | "provider.response"
   | "spend.committed"
   | "tool.started"
+  | "tool.blocked"
   | "tool.completed"
+  | "tool.failed"
   | "guardrail.violation";
 
 export interface CaptarEvent<TData = Record<string, unknown>> {
@@ -109,6 +127,7 @@ export interface CaptarEvent<TData = Record<string, unknown>> {
   timestamp: string;
   sessionId: string;
   trace: TraceContext;
+  span?: TraceSpanSnapshot;
   project?: string;
   metadata?: Metadata;
   data: TData;


### PR DESCRIPTION
## Linked Issue

- Closes #5

## Summary

- extend exported Captar event types with span snapshots and new request/tool failure states
- add stable span ids and parent links for session, request, and tool flows in the SDK runtime
- release reserved spend on provider or tool failures and cover the new behavior in SDK tests

## Validation

- [x] `pnpm --filter @captar/sdk lint`
- [x] `pnpm --filter @captar/sdk test`
- [x] Verified stable request span reuse and failure cleanup in the updated test suite

## Risk and Rollback

- Risk level: Medium
- Rollback plan: Revert this PR to restore the previous flat event-only tracing behavior

## Screenshots

- [x] No UI change
