### PR TITLE
feat: add platform span debugger

### DIFF
--- a/apps/platform/app/traces/[traceId]/page.tsx
+++ b/apps/platform/app/traces/[traceId]/page.tsx
@@ -1,10 +1,13 @@
 import { notFound } from "next/navigation";
 
 import { AppShell } from "../../../components/app-shell";
+import { TraceAutoRefresh } from "../../../components/trace-auto-refresh";
 import { Badge } from "../../../components/ui/badge";
-import { Card, CardContent, CardHeader, CardTitle } from "../../../components/ui/card";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../../../components/ui/card";
 import { Separator } from "../../../components/ui/separator";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "../../../components/ui/tabs";
 import { requireUser } from "../../../lib/auth-guard";
+import { buildTraceSpanTree, buildTraceTimeline, flattenTraceSpanTree, summarizeTraceFromSpans, type TraceSpanNode, type TraceTimelineItem } from "../../../lib/trace-spans";
 import { getTraceById } from "../../../lib/platform";
 
 export const dynamic = "force-dynamic";
@@ -22,75 +25,181 @@ export default async function TracePage({
     notFound();
   }
 
+  const summary = summarizeTraceFromSpans(trace.spans, trace.spendEntries);
+  const spanTree = buildTraceSpanTree(trace.spans);
+  const flattenedSpans = flattenTraceSpanTree(spanTree);
+  const timeline = buildTraceTimeline(trace.spans);
+  const timelineWindowMs = Math.max(
+    1,
+    ...timeline.map((item) => item.offsetMs + (item.durationMs ?? 0)),
+  );
+  const currentStatus = summary.status ?? trace.status;
+
   return (
     <AppShell userName={user.email}>
       <div className="grid gap-6">
+        <TraceAutoRefresh active={currentStatus === "RUNNING"} />
+
         <Card>
           <CardHeader>
-            <div className="flex items-center justify-between gap-4">
-              <div>
-                <CardTitle>{trace.model ?? "Unknown model"}</CardTitle>
-                <p className="mt-1 text-sm text-slate-400">{trace.provider ?? "Unknown provider"}</p>
+            <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+              <div className="space-y-2">
+                <div className="flex items-center gap-2">
+                  <CardTitle>{trace.externalTraceId}</CardTitle>
+                  <Badge>{currentStatus}</Badge>
+                </div>
+                <CardDescription>
+                  Trace for hook <span className="font-mono text-xs text-cyan-300">{trace.hook.publicId}</span>
+                </CardDescription>
+                <p className="text-sm text-slate-400">
+                  Latest model: {trace.model ?? "unknown"} · Provider: {trace.provider ?? "unknown"}
+                </p>
               </div>
-              <Badge>{trace.status}</Badge>
+              <div className="text-sm text-slate-400">
+                <p>Session: <span className="font-mono text-xs">{trace.llmSession.externalSessionId}</span></p>
+                <p>Started: {formatTimestamp(summary.startedAt ?? trace.startedAt)}</p>
+                <p>Completed: {summary.completedAt ? formatTimestamp(summary.completedAt) : "running"}</p>
+              </div>
             </div>
           </CardHeader>
-          <CardContent className="grid gap-4 md:grid-cols-4">
-            <div className="rounded-xl border border-slate-800 bg-slate-900/60 p-4">
-              <p className="text-sm text-slate-400">Estimated</p>
-              <p className="text-xl font-semibold">${Number(trace.estimatedCostUsd).toFixed(4)}</p>
-            </div>
-            <div className="rounded-xl border border-slate-800 bg-slate-900/60 p-4">
-              <p className="text-sm text-slate-400">Actual</p>
-              <p className="text-xl font-semibold">${Number(trace.actualCostUsd).toFixed(4)}</p>
-            </div>
-            <div className="rounded-xl border border-slate-800 bg-slate-900/60 p-4">
-              <p className="text-sm text-slate-400">Input tokens</p>
-              <p className="text-xl font-semibold">{trace.inputTokens ?? 0}</p>
-            </div>
-            <div className="rounded-xl border border-slate-800 bg-slate-900/60 p-4">
-              <p className="text-sm text-slate-400">Output tokens</p>
-              <p className="text-xl font-semibold">{trace.outputTokens ?? 0}</p>
-            </div>
+          <CardContent className="grid gap-4 md:grid-cols-5">
+            <MetricCard label="Estimated" value={formatUsd(summary.estimatedCostUsd)} />
+            <MetricCard label="Actual" value={formatUsd(summary.actualCostUsd)} />
+            <MetricCard label="Input tokens" value={String(summary.inputTokens)} />
+            <MetricCard label="Output tokens" value={String(summary.outputTokens)} />
+            <MetricCard label="Spans" value={String(trace.spans.length)} />
           </CardContent>
         </Card>
 
-        <div className="grid gap-6 xl:grid-cols-[1.2fr_0.8fr]">
+        <div className="grid gap-6 xl:grid-cols-[1.25fr_0.75fr]">
           <Card>
             <CardHeader>
-              <CardTitle>Trace timeline</CardTitle>
+              <CardTitle>Trace Debugger</CardTitle>
+              <CardDescription>
+                Explore the trace as a tree, a timeline, or raw events.
+              </CardDescription>
             </CardHeader>
-            <CardContent className="space-y-4">
-              {trace.events.map((event) => (
-                <div key={event.id} className="rounded-xl border border-slate-800 bg-slate-900/60 p-4">
-                  <div className="flex items-center justify-between gap-4">
-                    <div className="font-medium">{event.type}</div>
-                    <div className="text-xs text-slate-500">{event.timestamp.toISOString()}</div>
+            <CardContent>
+              <Tabs defaultValue="tree">
+                <TabsList>
+                  <TabsTrigger value="tree">Tree</TabsTrigger>
+                  <TabsTrigger value="timeline">Timeline</TabsTrigger>
+                  <TabsTrigger value="events">Events</TabsTrigger>
+                  <TabsTrigger value="violations">Violations</TabsTrigger>
+                </TabsList>
+
+                <TabsContent value="tree" className="pt-4">
+                  {spanTree.length ? (
+                    <div className="space-y-3">
+                      {spanTree.map((node) => (
+                        <TraceTreeNode key={node.externalSpanId} node={node} />
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="text-sm text-slate-400">No spans captured yet.</p>
+                  )}
+                </TabsContent>
+
+                <TabsContent value="timeline" className="pt-4">
+                  {timeline.length ? (
+                    <div className="space-y-4">
+                      {timeline.map((item) => (
+                        <TraceTimelineRow
+                          key={item.externalSpanId}
+                          item={item}
+                          timelineWindowMs={timelineWindowMs}
+                        />
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="text-sm text-slate-400">No timeline data captured yet.</p>
+                  )}
+                </TabsContent>
+
+                <TabsContent value="events" className="pt-4">
+                  <div className="space-y-4">
+                    {trace.events.map((event) => (
+                      <div key={event.id} className="rounded-xl border border-slate-800 bg-slate-900/60 p-4">
+                        <div className="flex items-center justify-between gap-4">
+                          <div className="font-medium">{event.type}</div>
+                          <div className="text-xs text-slate-500">{event.timestamp.toISOString()}</div>
+                        </div>
+                        <Separator className="my-3" />
+                        <pre className="overflow-x-auto text-xs text-slate-300">
+                          {JSON.stringify(event.data, null, 2)}
+                        </pre>
+                      </div>
+                    ))}
                   </div>
-                  <Separator className="my-3" />
-                  <pre className="text-xs text-slate-300">{JSON.stringify(event.data, null, 2)}</pre>
-                </div>
-              ))}
+                </TabsContent>
+
+                <TabsContent value="violations" className="pt-4">
+                  {trace.violations.length ? (
+                    <div className="space-y-3">
+                      {trace.violations.map((violation) => (
+                        <div key={violation.id} className="rounded-xl border border-slate-800 bg-slate-900/60 p-4">
+                          <div className="flex items-center gap-2">
+                            <Badge>{violation.category}</Badge>
+                            <span className="text-sm text-slate-400">{violation.eventType}</span>
+                          </div>
+                          <p className="mt-3 font-medium">{violation.message}</p>
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="text-sm text-slate-400">No violations recorded on this trace.</p>
+                  )}
+                </TabsContent>
+              </Tabs>
             </CardContent>
           </Card>
 
           <div className="grid gap-6">
             <Card>
               <CardHeader>
-                <CardTitle>Prompt payload</CardTitle>
+                <CardTitle>Span Summary</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-3 text-sm text-slate-300">
+                {flattenedSpans.length ? (
+                  flattenedSpans.map((span) => (
+                    <div key={span.externalSpanId} className="rounded-xl border border-slate-800 bg-slate-900/60 p-3">
+                      <div className="flex items-center justify-between gap-4">
+                        <div style={{ paddingLeft: `${span.depth * 14}px` }}>
+                          <p className="font-medium">{span.name}</p>
+                          <p className="text-xs text-slate-400">
+                            {span.kind} · {span.status}
+                          </p>
+                        </div>
+                        <div className="text-right text-xs text-slate-400">
+                          <p>{formatTimestamp(span.startedAt)}</p>
+                          <p>{formatDuration(span.durationMs)}</p>
+                        </div>
+                      </div>
+                    </div>
+                  ))
+                ) : (
+                  <p className="text-slate-400">No span summaries available yet.</p>
+                )}
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>Prompt Payload</CardTitle>
               </CardHeader>
               <CardContent>
-                <pre className="rounded-xl border border-slate-800 bg-slate-900 p-4 text-sm">
+                <pre className="overflow-x-auto rounded-xl border border-slate-800 bg-slate-900 p-4 text-sm">
                   {trace.promptPayload?.contentRedacted ?? "No prompt payload"}
                 </pre>
               </CardContent>
             </Card>
+
             <Card>
               <CardHeader>
-                <CardTitle>Response payload</CardTitle>
+                <CardTitle>Response Payload</CardTitle>
               </CardHeader>
               <CardContent>
-                <pre className="rounded-xl border border-slate-800 bg-slate-900 p-4 text-sm">
+                <pre className="overflow-x-auto rounded-xl border border-slate-800 bg-slate-900 p-4 text-sm">
                   {trace.responsePayload?.contentRedacted ?? "No response payload"}
                 </pre>
               </CardContent>
@@ -100,4 +209,112 @@ export default async function TracePage({
       </div>
     </AppShell>
   );
+}
+
+function MetricCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-xl border border-slate-800 bg-slate-900/60 p-4">
+      <p className="text-sm text-slate-400">{label}</p>
+      <p className="text-xl font-semibold">{value}</p>
+    </div>
+  );
+}
+
+function TraceTreeNode({ node }: { node: TraceSpanNode }) {
+  return (
+    <div className="space-y-3">
+      <div
+        className="rounded-xl border border-slate-800 bg-slate-900/60 p-4"
+        style={{ marginLeft: `${node.depth * 18}px` }}
+      >
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <div className="flex items-center gap-2">
+              <p className="font-medium">{node.name}</p>
+              <Badge>{node.kind}</Badge>
+              <Badge>{node.status}</Badge>
+            </div>
+            <p className="mt-2 text-xs text-slate-400">
+              Started {formatTimestamp(node.startedAt)} · {formatDuration(node.durationMs)}
+            </p>
+          </div>
+          <div className="text-right text-xs text-slate-400">
+            {node.attributes.model ? <p>Model: {String(node.attributes.model)}</p> : null}
+            {typeof node.attributes.costUsd === "number" ? (
+              <p>Cost: {formatUsd(node.attributes.costUsd)}</p>
+            ) : null}
+            {node.attributes.toolName ? <p>Tool: {String(node.attributes.toolName)}</p> : null}
+          </div>
+        </div>
+      </div>
+
+      {node.children.map((child) => (
+        <TraceTreeNode key={child.externalSpanId} node={child} />
+      ))}
+    </div>
+  );
+}
+
+function TraceTimelineRow({
+  item,
+  timelineWindowMs,
+}: {
+  item: TraceTimelineItem;
+  timelineWindowMs: number;
+}) {
+  const left = (item.offsetMs / timelineWindowMs) * 100;
+  const width = item.durationMs
+    ? Math.max((item.durationMs / timelineWindowMs) * 100, 6)
+    : 8;
+
+  return (
+    <div className="grid gap-2 md:grid-cols-[220px_minmax(0,1fr)] md:items-center">
+      <div className="text-sm text-slate-300">
+        <p className="font-medium">{item.name}</p>
+        <p className="text-xs text-slate-400">
+          {item.kind} · {item.status} · {formatDuration(item.durationMs)}
+        </p>
+      </div>
+      <div className="relative h-12 rounded-xl border border-slate-800 bg-slate-950">
+        <div
+          className={`absolute top-2 h-8 rounded-lg ${statusBarClass(item.status)}`}
+          style={{
+            left: `${Math.min(left, 92)}%`,
+            width: `${Math.min(width, 100 - Math.min(left, 92))}%`,
+          }}
+        />
+      </div>
+    </div>
+  );
+}
+
+function statusBarClass(status: string) {
+  switch (status) {
+    case "FAILED":
+      return "bg-rose-500/80";
+    case "BLOCKED":
+      return "bg-amber-500/80";
+    case "COMPLETED":
+      return "bg-cyan-500/80";
+    default:
+      return "bg-slate-500/80";
+  }
+}
+
+function formatUsd(value: number) {
+  return `$${value.toFixed(4)}`;
+}
+
+function formatTimestamp(value: Date) {
+  return value.toISOString();
+}
+
+function formatDuration(value?: number) {
+  if (typeof value !== "number") {
+    return "running";
+  }
+  if (value < 1000) {
+    return `${value}ms`;
+  }
+  return `${(value / 1000).toFixed(2)}s`;
 }

--- a/apps/platform/components/trace-auto-refresh.tsx
+++ b/apps/platform/components/trace-auto-refresh.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+
+export function TraceAutoRefresh({
+  active,
+  intervalMs = 4_000,
+}: {
+  active: boolean;
+  intervalMs?: number;
+}) {
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!active) {
+      return undefined;
+    }
+
+    const interval = window.setInterval(() => {
+      router.refresh();
+    }, intervalMs);
+
+    return () => {
+      window.clearInterval(interval);
+    };
+  }, [active, intervalMs, router]);
+
+  if (!active) {
+    return null;
+  }
+
+  return (
+    <div className="rounded-xl border border-cyan-500/30 bg-cyan-500/10 p-3 text-sm text-cyan-100">
+      Live trace polling is enabled while spans are still running.
+    </div>
+  );
+}

--- a/apps/platform/lib/platform.ts
+++ b/apps/platform/lib/platform.ts
@@ -3,13 +3,16 @@ import {
   LedgerKind,
   PayloadRetention,
   ProjectRole,
+  TraceSpanKind,
+  TraceSpanStatus,
   TraceStatus,
   type Prisma,
 } from "@prisma/client";
-import type { ExportBatch } from "@captar/types";
+import type { ExportBatch, TraceSpanSnapshot } from "@captar/types";
 
 import { prisma } from "./db";
 import { extractPromptContent, extractResponseContent, redactContent } from "./redaction";
+import { summarizeTraceFromSpans } from "./trace-spans";
 import { slugify } from "./utils";
 
 function decimalToNumber(value: Prisma.Decimal | number | null | undefined) {
@@ -17,6 +20,162 @@ function decimalToNumber(value: Prisma.Decimal | number | null | undefined) {
     return 0;
   }
   return typeof value === "number" ? value : Number(value);
+}
+
+function jsonObjectOrUndefined(
+  value: Record<string, unknown> | null | undefined,
+): Prisma.JsonObject | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  return Object.fromEntries(
+    Object.entries(value).filter(([, entryValue]) => entryValue !== undefined),
+  ) as Prisma.JsonObject;
+}
+
+function traceSpanToJson(span: TraceSpanSnapshot | undefined): Prisma.JsonObject | undefined {
+  if (!span) {
+    return undefined;
+  }
+
+  return jsonObjectOrUndefined({
+    id: span.id,
+    parentId: span.parentId ?? null,
+    name: span.name,
+    kind: span.kind,
+    status: span.status,
+    startedAt: span.startedAt,
+    endedAt: span.endedAt ?? null,
+    attributes: span.attributes ? jsonObjectOrUndefined(span.attributes) : undefined,
+  });
+}
+
+function toTraceSpanKind(kind: string | undefined): TraceSpanKind {
+  switch ((kind ?? "").toLowerCase()) {
+    case "session":
+      return TraceSpanKind.SESSION;
+    case "tool":
+      return TraceSpanKind.TOOL;
+    case "request":
+    default:
+      return TraceSpanKind.REQUEST;
+  }
+}
+
+function toTraceSpanStatus(status: string | undefined): TraceSpanStatus {
+  switch ((status ?? "").toLowerCase()) {
+    case "completed":
+      return TraceSpanStatus.COMPLETED;
+    case "blocked":
+      return TraceSpanStatus.BLOCKED;
+    case "failed":
+      return TraceSpanStatus.FAILED;
+    case "running":
+    default:
+      return TraceSpanStatus.RUNNING;
+  }
+}
+
+function violationCategoryForEvent(
+  eventType: string,
+  data: Record<string, unknown>,
+): string {
+  if (typeof data.category === "string") {
+    return data.category;
+  }
+
+  switch (eventType) {
+    case "request.blocked":
+      return "access";
+    case "tool.blocked":
+      return "workflow";
+    case "request.failed":
+    case "tool.failed":
+      return "execution";
+    default:
+      return "workflow";
+  }
+}
+
+async function upsertTraceSpanFromEvent(
+  traceDbId: string,
+  event: NonNullable<ExportBatch["events"]>[number],
+  eventAlreadyExists: boolean,
+) {
+  if (!event.span) {
+    return;
+  }
+
+  await prisma.traceSpan.upsert({
+    where: {
+      traceId_externalSpanId: {
+        traceId: traceDbId,
+        externalSpanId: event.span.id,
+      },
+    },
+    update: {
+      externalParentSpanId: event.span.parentId ?? null,
+      name: event.span.name,
+      kind: toTraceSpanKind(event.span.kind),
+      status: toTraceSpanStatus(event.span.status),
+      startedAt: new Date(event.span.startedAt),
+      endedAt: event.span.endedAt ? new Date(event.span.endedAt) : null,
+      attributes: event.span.attributes
+        ? jsonObjectOrUndefined(event.span.attributes)
+        : undefined,
+      lastEventAt: new Date(event.timestamp),
+      ...(eventAlreadyExists ? {} : { eventCount: { increment: 1 } }),
+    },
+    create: {
+      traceId: traceDbId,
+      externalSpanId: event.span.id,
+      externalParentSpanId: event.span.parentId ?? null,
+      name: event.span.name,
+      kind: toTraceSpanKind(event.span.kind),
+      status: toTraceSpanStatus(event.span.status),
+      startedAt: new Date(event.span.startedAt),
+      endedAt: event.span.endedAt ? new Date(event.span.endedAt) : null,
+      attributes: event.span.attributes
+        ? jsonObjectOrUndefined(event.span.attributes)
+        : undefined,
+      eventCount: 1,
+      lastEventAt: new Date(event.timestamp),
+    },
+  });
+}
+
+async function syncTraceDerivedState(traceDbId: string) {
+  const trace = await prisma.trace.findUnique({
+    where: { id: traceDbId },
+    include: {
+      spans: {
+        orderBy: { startedAt: "asc" },
+      },
+      spendEntries: true,
+    },
+  });
+
+  if (!trace) {
+    return;
+  }
+
+  const summary = summarizeTraceFromSpans(trace.spans, trace.spendEntries);
+
+  await prisma.trace.update({
+    where: { id: traceDbId },
+    data: {
+      status: summary.status,
+      startedAt: summary.startedAt ?? trace.startedAt,
+      completedAt: summary.status === TraceStatus.RUNNING ? null : summary.completedAt,
+      estimatedCostUsd: summary.estimatedCostUsd,
+      actualCostUsd: summary.actualCostUsd,
+      inputTokens: summary.inputTokens > 0 ? summary.inputTokens : null,
+      outputTokens: summary.outputTokens > 0 ? summary.outputTokens : null,
+      cachedInputTokens:
+        summary.cachedInputTokens > 0 ? summary.cachedInputTokens : null,
+    },
+  });
 }
 
 export async function listUserProjects(userId: string) {
@@ -230,6 +389,9 @@ export async function getTraceById(traceId: string, userId: string) {
       llmSession: true,
       promptPayload: true,
       responsePayload: true,
+      spans: {
+        orderBy: { startedAt: "asc" },
+      },
       events: {
         orderBy: { timestamp: "asc" },
       },
@@ -244,9 +406,9 @@ export async function getTraceById(traceId: string, userId: string) {
 }
 
 function findOrCreateTraceState(
-  state: Map<string, { traceDbId: string; hookDbId: string; sessionDbId: string }>,
+  state: Map<string, { traceDbId: string; sessionDbId: string }>,
   key: string,
-  value: { traceDbId: string; hookDbId: string; sessionDbId: string },
+  value: { traceDbId: string; sessionDbId: string },
 ) {
   if (!state.has(key)) {
     state.set(key, value);
@@ -272,9 +434,14 @@ export async function ingestHookBatch(hookId: string, batch: Partial<ExportBatch
   }
 
   const activePolicy = hook.policies[0] ?? null;
-  const traceState = new Map<string, { traceDbId: string; hookDbId: string; sessionDbId: string }>();
+  const traceState = new Map<string, { traceDbId: string; sessionDbId: string }>();
+  const affectedTraceIds = new Set<string>();
+  const orderedEvents = [...(batch.events ?? [])].sort(
+    (left, right) =>
+      new Date(left.timestamp).getTime() - new Date(right.timestamp).getTime(),
+  );
 
-  for (const event of batch.events ?? []) {
+  for (const event of orderedEvents) {
     const session = await prisma.lLMSession.upsert({
       where: {
         externalSessionId: event.sessionId,
@@ -320,10 +487,22 @@ export async function ingestHookBatch(hookId: string, batch: Partial<ExportBatch
       traceDbId = trace.id;
       findOrCreateTraceState(traceState, traceKey, {
         traceDbId,
-        hookDbId: hook.id,
         sessionDbId: session.id,
       });
     }
+    affectedTraceIds.add(traceDbId);
+
+    const existingTraceEvent = await prisma.traceEvent.findUnique({
+      where: {
+        traceDbId_externalEventId: {
+          traceDbId,
+          externalEventId: event.id,
+        },
+      },
+      select: {
+        id: true,
+      },
+    });
 
     await prisma.traceEvent.upsert({
       where: {
@@ -336,6 +515,7 @@ export async function ingestHookBatch(hookId: string, batch: Partial<ExportBatch
         type: event.type,
         timestamp: new Date(event.timestamp),
         data: event.data as Prisma.JsonObject,
+        spanData: traceSpanToJson(event.span),
         metadata: event.metadata ? (event.metadata as Prisma.JsonObject) : undefined,
       },
       create: {
@@ -344,9 +524,22 @@ export async function ingestHookBatch(hookId: string, batch: Partial<ExportBatch
         type: event.type,
         timestamp: new Date(event.timestamp),
         data: event.data as Prisma.JsonObject,
+        spanData: traceSpanToJson(event.span),
         metadata: event.metadata ? (event.metadata as Prisma.JsonObject) : undefined,
       },
     });
+    await upsertTraceSpanFromEvent(traceDbId, event, Boolean(existingTraceEvent));
+
+    if (event.type === "session.started") {
+      await prisma.trace.update({
+        where: { id: traceDbId },
+        data: {
+          startedAt: new Date(event.timestamp),
+          status: TraceStatus.RUNNING,
+          metadata: event.metadata ? (event.metadata as Prisma.JsonObject) : undefined,
+        },
+      });
+    }
 
     if (event.type === "request.started") {
       const data = event.data as Record<string, unknown>;
@@ -393,12 +586,6 @@ export async function ingestHookBatch(hookId: string, batch: Partial<ExportBatch
         data: {
           provider: typeof data.provider === "string" ? data.provider : undefined,
           model: typeof data.model === "string" ? data.model : undefined,
-          inputTokens: typeof data.inputTokens === "number" ? data.inputTokens : undefined,
-          outputTokens: typeof data.outputTokens === "number" ? data.outputTokens : undefined,
-          cachedInputTokens:
-            typeof data.cachedInputTokens === "number" ? data.cachedInputTokens : undefined,
-          actualCostUsd:
-            typeof data.costUsd === "number" ? data.costUsd : undefined,
         },
       });
 
@@ -423,11 +610,25 @@ export async function ingestHookBatch(hookId: string, batch: Partial<ExportBatch
     if (event.type === "estimate.reserved" || event.type === "spend.committed") {
       const data = event.data as Record<string, unknown>;
       if (event.type === "estimate.reserved" && typeof data.reservedUsd === "number") {
-        await prisma.spendLedger.create({
-          data: {
+        await prisma.spendLedger.upsert({
+          where: {
+            hookId_sourceEventId_kind: {
+              hookId: hook.id,
+              sourceEventId: event.id,
+              kind: LedgerKind.RESERVED,
+            },
+          },
+          update: {
+            amountUsd: data.reservedUsd,
+            metadata: data as Prisma.JsonObject,
+            llmSessionId: session.id,
+            traceId: traceDbId,
+          },
+          create: {
             hookId: hook.id,
             llmSessionId: session.id,
             traceId: traceDbId,
+            sourceEventId: event.id,
             kind: LedgerKind.RESERVED,
             amountUsd: data.reservedUsd,
             metadata: data as Prisma.JsonObject,
@@ -437,11 +638,25 @@ export async function ingestHookBatch(hookId: string, batch: Partial<ExportBatch
 
       if (event.type === "spend.committed") {
         if (typeof data.actualCostUsd === "number") {
-          await prisma.spendLedger.create({
-            data: {
+          await prisma.spendLedger.upsert({
+            where: {
+              hookId_sourceEventId_kind: {
+                hookId: hook.id,
+                sourceEventId: event.id,
+                kind: LedgerKind.COMMITTED,
+              },
+            },
+            update: {
+              amountUsd: data.actualCostUsd,
+              metadata: data as Prisma.JsonObject,
+              llmSessionId: session.id,
+              traceId: traceDbId,
+            },
+            create: {
               hookId: hook.id,
               llmSessionId: session.id,
               traceId: traceDbId,
+              sourceEventId: event.id,
               kind: LedgerKind.COMMITTED,
               amountUsd: data.actualCostUsd,
               metadata: data as Prisma.JsonObject,
@@ -449,11 +664,25 @@ export async function ingestHookBatch(hookId: string, batch: Partial<ExportBatch
           });
         }
         if (typeof data.releasedUsd === "number" && data.releasedUsd > 0) {
-          await prisma.spendLedger.create({
-            data: {
+          await prisma.spendLedger.upsert({
+            where: {
+              hookId_sourceEventId_kind: {
+                hookId: hook.id,
+                sourceEventId: event.id,
+                kind: LedgerKind.RELEASED,
+              },
+            },
+            update: {
+              amountUsd: data.releasedUsd,
+              metadata: data as Prisma.JsonObject,
+              llmSessionId: session.id,
+              traceId: traceDbId,
+            },
+            create: {
               hookId: hook.id,
               llmSessionId: session.id,
               traceId: traceDbId,
+              sourceEventId: event.id,
               kind: LedgerKind.RELEASED,
               amountUsd: data.releasedUsd,
               metadata: data as Prisma.JsonObject,
@@ -463,28 +692,39 @@ export async function ingestHookBatch(hookId: string, batch: Partial<ExportBatch
       }
     }
 
-    if (event.type === "request.blocked" || event.type === "guardrail.violation") {
+    if (
+      event.type === "request.blocked" ||
+      event.type === "tool.blocked" ||
+      event.type === "request.failed" ||
+      event.type === "tool.failed" ||
+      event.type === "guardrail.violation"
+    ) {
       const data = event.data as Record<string, unknown>;
-      await prisma.violation.create({
-        data: {
-          hookId: hook.id,
+      await prisma.violation.upsert({
+        where: {
+          hookId_sourceEventId: {
+            hookId: hook.id,
+            sourceEventId: event.id,
+          },
+        },
+        update: {
           llmSessionId: session.id,
           traceId: traceDbId,
-          category:
-            typeof data.category === "string"
-              ? data.category
-              : event.type === "request.blocked"
-                ? "access"
-                : "workflow",
+          category: violationCategoryForEvent(event.type, data),
           eventType: event.type,
           message: String(data.reason ?? data.message ?? "Guardrail violation"),
           details: data as Prisma.JsonObject,
         },
-      });
-
-      await prisma.trace.update({
-        where: { id: traceDbId },
-        data: { status: TraceStatus.BLOCKED },
+        create: {
+          hookId: hook.id,
+          llmSessionId: session.id,
+          traceId: traceDbId,
+          sourceEventId: event.id,
+          category: violationCategoryForEvent(event.type, data),
+          eventType: event.type,
+          message: String(data.reason ?? data.message ?? "Guardrail violation"),
+          details: data as Prisma.JsonObject,
+        },
       });
     }
 
@@ -506,6 +746,10 @@ export async function ingestHookBatch(hookId: string, batch: Partial<ExportBatch
         },
       });
     }
+  }
+
+  for (const traceDbId of affectedTraceIds) {
+    await syncTraceDerivedState(traceDbId);
   }
 
   return {

--- a/apps/platform/lib/trace-spans.ts
+++ b/apps/platform/lib/trace-spans.ts
@@ -1,0 +1,200 @@
+import { LedgerKind, TraceStatus } from "@prisma/client";
+
+interface TraceSpanLike {
+  externalSpanId: string;
+  externalParentSpanId?: string | null;
+  name: string;
+  kind: string;
+  status: string;
+  startedAt: Date;
+  endedAt?: Date | null;
+  attributes?: unknown;
+}
+
+interface SpendEntryLike {
+  kind: LedgerKind;
+  amountUsd: number | { toString(): string };
+}
+
+export interface TraceSpanNode extends TraceSpanLike {
+  attributes: Record<string, unknown>;
+  children: TraceSpanNode[];
+  depth: number;
+  durationMs?: number;
+}
+
+export interface TraceTimelineItem extends TraceSpanLike {
+  attributes: Record<string, unknown>;
+  durationMs?: number;
+  offsetMs: number;
+}
+
+function asObject(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return {};
+  }
+  return value as Record<string, unknown>;
+}
+
+function toNumber(value: number | { toString(): string } | unknown): number {
+  if (typeof value === "number") {
+    return value;
+  }
+  if (value && typeof value === "object" && "toString" in value) {
+    return Number(value.toString());
+  }
+  return Number(value ?? 0);
+}
+
+function attributeNumber(value: unknown): number {
+  if (typeof value === "number") {
+    return value;
+  }
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+  return 0;
+}
+
+function durationMs(span: Pick<TraceSpanLike, "startedAt" | "endedAt">): number | undefined {
+  if (!span.endedAt) {
+    return undefined;
+  }
+  return Math.max(0, span.endedAt.getTime() - span.startedAt.getTime());
+}
+
+export function deriveTraceStatusFromSpans(spans: Array<Pick<TraceSpanLike, "status">>): TraceStatus {
+  if (spans.some((span) => span.status === "FAILED")) {
+    return TraceStatus.FAILED;
+  }
+  if (spans.some((span) => span.status === "BLOCKED")) {
+    return TraceStatus.BLOCKED;
+  }
+  if (spans.some((span) => span.status === "RUNNING")) {
+    return TraceStatus.RUNNING;
+  }
+  return TraceStatus.COMPLETED;
+}
+
+export function summarizeTraceFromSpans(
+  spans: TraceSpanLike[],
+  spendEntries: SpendEntryLike[],
+) {
+  const orderedSpans = [...spans].sort(
+    (left, right) => left.startedAt.getTime() - right.startedAt.getTime(),
+  );
+  const startedAt = orderedSpans[0]?.startedAt ?? null;
+  const completedAt =
+    orderedSpans.length > 0 && orderedSpans.every((span) => span.endedAt)
+      ? orderedSpans.reduce<Date | null>((latest, span) => {
+          if (!span.endedAt) {
+            return latest;
+          }
+          if (!latest || span.endedAt.getTime() > latest.getTime()) {
+            return span.endedAt;
+          }
+          return latest;
+        }, null)
+      : null;
+
+  const tokenSummary = orderedSpans.reduce(
+    (totals, span) => {
+      if (span.kind !== "REQUEST") {
+        return totals;
+      }
+
+      const attributes = asObject(span.attributes);
+      totals.inputTokens += attributeNumber(attributes.inputTokens);
+      totals.outputTokens += attributeNumber(attributes.outputTokens);
+      totals.cachedInputTokens += attributeNumber(attributes.cachedInputTokens);
+      return totals;
+    },
+    {
+      inputTokens: 0,
+      outputTokens: 0,
+      cachedInputTokens: 0,
+    },
+  );
+
+  const estimatedCostUsd = spendEntries
+    .filter((entry) => entry.kind === LedgerKind.RESERVED)
+    .reduce((total, entry) => total + toNumber(entry.amountUsd), 0);
+  const actualCostUsd = spendEntries
+    .filter((entry) => entry.kind === LedgerKind.COMMITTED)
+    .reduce((total, entry) => total + toNumber(entry.amountUsd), 0);
+
+  return {
+    status: deriveTraceStatusFromSpans(orderedSpans),
+    startedAt,
+    completedAt,
+    estimatedCostUsd,
+    actualCostUsd,
+    inputTokens: tokenSummary.inputTokens,
+    outputTokens: tokenSummary.outputTokens,
+    cachedInputTokens: tokenSummary.cachedInputTokens,
+  };
+}
+
+export function buildTraceSpanTree(spans: TraceSpanLike[]): TraceSpanNode[] {
+  const sortedSpans = [...spans].sort(
+    (left, right) => left.startedAt.getTime() - right.startedAt.getTime(),
+  );
+  const nodeMap = new Map<string, TraceSpanNode>();
+
+  for (const span of sortedSpans) {
+    nodeMap.set(span.externalSpanId, {
+      ...span,
+      attributes: asObject(span.attributes),
+      children: [],
+      depth: 0,
+      durationMs: durationMs(span),
+    });
+  }
+
+  const roots: TraceSpanNode[] = [];
+
+  for (const span of sortedSpans) {
+    const node = nodeMap.get(span.externalSpanId);
+    if (!node) {
+      continue;
+    }
+
+    const parentId = span.externalParentSpanId ?? undefined;
+    const parentNode = parentId ? nodeMap.get(parentId) : undefined;
+    if (!parentNode) {
+      roots.push(node);
+      continue;
+    }
+
+    node.depth = parentNode.depth + 1;
+    parentNode.children.push(node);
+  }
+
+  return roots;
+}
+
+export function flattenTraceSpanTree(nodes: TraceSpanNode[]): TraceSpanNode[] {
+  const flattened: TraceSpanNode[] = [];
+
+  for (const node of nodes) {
+    flattened.push(node);
+    flattened.push(...flattenTraceSpanTree(node.children));
+  }
+
+  return flattened;
+}
+
+export function buildTraceTimeline(spans: TraceSpanLike[]): TraceTimelineItem[] {
+  const sortedSpans = [...spans].sort(
+    (left, right) => left.startedAt.getTime() - right.startedAt.getTime(),
+  );
+  const firstStart = sortedSpans[0]?.startedAt.getTime() ?? 0;
+
+  return sortedSpans.map((span) => ({
+    ...span,
+    attributes: asObject(span.attributes),
+    durationMs: durationMs(span),
+    offsetMs: Math.max(0, span.startedAt.getTime() - firstStart),
+  }));
+}

--- a/apps/platform/package.json
+++ b/apps/platform/package.json
@@ -7,7 +7,7 @@
     "dev": "node -e \"require('node:fs').rmSync('.next',{recursive:true,force:true})\" && next dev",
     "build": "node -e \"require('node:fs').rmSync('.next',{recursive:true,force:true})\" && next build",
     "lint": "tsc -p tsconfig.lint.json --noEmit",
-    "test": "node -e \"console.log('platform smoke: ok')\""
+    "test": "vitest run"
   },
   "dependencies": {
     "@auth/prisma-adapter": "^2.7.4",

--- a/apps/platform/test/trace-spans.test.ts
+++ b/apps/platform/test/trace-spans.test.ts
@@ -1,0 +1,72 @@
+import { LedgerKind, TraceStatus } from "@prisma/client";
+import { describe, expect, it } from "vitest";
+
+import { buildTraceSpanTree, buildTraceTimeline, summarizeTraceFromSpans } from "../lib/trace-spans";
+
+describe("trace span helpers", () => {
+  const spans = [
+    {
+      externalSpanId: "session",
+      name: "session",
+      kind: "SESSION",
+      status: "COMPLETED",
+      startedAt: new Date("2026-04-08T00:00:00.000Z"),
+      endedAt: new Date("2026-04-08T00:00:10.000Z"),
+      attributes: { sessionId: "session_1" },
+    },
+    {
+      externalSpanId: "request",
+      externalParentSpanId: "session",
+      name: "responses.create",
+      kind: "REQUEST",
+      status: "COMPLETED",
+      startedAt: new Date("2026-04-08T00:00:01.000Z"),
+      endedAt: new Date("2026-04-08T00:00:05.000Z"),
+      attributes: { inputTokens: 120, outputTokens: 40, costUsd: 0.12 },
+    },
+    {
+      externalSpanId: "tool",
+      externalParentSpanId: "session",
+      name: "search.docs",
+      kind: "TOOL",
+      status: "FAILED",
+      startedAt: new Date("2026-04-08T00:00:06.000Z"),
+      endedAt: new Date("2026-04-08T00:00:08.000Z"),
+      attributes: { toolName: "search.docs" },
+    },
+  ];
+
+  it("builds a nested trace tree using parent span ids", () => {
+    const tree = buildTraceSpanTree(spans);
+
+    expect(tree).toHaveLength(1);
+    expect(tree[0]?.externalSpanId).toBe("session");
+    expect(tree[0]?.children.map((child) => child.externalSpanId)).toEqual([
+      "request",
+      "tool",
+    ]);
+  });
+
+  it("summarizes status, tokens, and costs from spans and ledgers", () => {
+    const summary = summarizeTraceFromSpans(spans, [
+      { kind: LedgerKind.RESERVED, amountUsd: 0.2 },
+      { kind: LedgerKind.COMMITTED, amountUsd: 0.12 },
+      { kind: LedgerKind.RELEASED, amountUsd: 0.08 },
+    ]);
+
+    expect(summary.status).toBe(TraceStatus.FAILED);
+    expect(summary.inputTokens).toBe(120);
+    expect(summary.outputTokens).toBe(40);
+    expect(summary.estimatedCostUsd).toBeCloseTo(0.2);
+    expect(summary.actualCostUsd).toBeCloseTo(0.12);
+  });
+
+  it("builds timeline offsets from span start times", () => {
+    const timeline = buildTraceTimeline(spans);
+
+    expect(timeline[0]?.offsetMs).toBe(0);
+    expect(timeline[1]?.offsetMs).toBe(1000);
+    expect(timeline[2]?.offsetMs).toBe(6000);
+  });
+});
+

--- a/apps/platform/vitest.config.ts
+++ b/apps/platform/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["test/**/*.test.ts"],
+  },
+});

--- a/db/prisma/schema.prisma
+++ b/db/prisma/schema.prisma
@@ -32,6 +32,19 @@ enum TraceStatus {
   BLOCKED
 }
 
+enum TraceSpanKind {
+  SESSION
+  REQUEST
+  TOOL
+}
+
+enum TraceSpanStatus {
+  RUNNING
+  COMPLETED
+  FAILED
+  BLOCKED
+}
+
 enum LedgerKind {
   RESERVED
   COMMITTED
@@ -206,6 +219,7 @@ model Trace {
   updatedAt        DateTime       @updatedAt
   hook             HookConnection @relation(fields: [hookId], references: [id], onDelete: Cascade)
   llmSession       LLMSession     @relation(fields: [llmSessionId], references: [id], onDelete: Cascade)
+  spans            TraceSpan[]
   events           TraceEvent[]
   promptPayload    PromptPayload?
   responsePayload  ResponsePayload?
@@ -221,12 +235,34 @@ model TraceEvent {
   type            String
   timestamp       DateTime
   data            Json
+  spanData        Json?
   metadata        Json?
   traceDbId       String
   createdAt       DateTime @default(now())
   trace           Trace    @relation(fields: [traceDbId], references: [id], onDelete: Cascade)
 
   @@unique([traceDbId, externalEventId])
+}
+
+model TraceSpan {
+  id                   String          @id @default(cuid())
+  externalSpanId       String
+  externalParentSpanId String?
+  name                 String
+  kind                 TraceSpanKind
+  status               TraceSpanStatus @default(RUNNING)
+  startedAt            DateTime
+  endedAt              DateTime?
+  attributes           Json?
+  eventCount           Int             @default(0)
+  lastEventAt          DateTime?
+  traceId              String
+  createdAt            DateTime        @default(now())
+  updatedAt            DateTime        @updatedAt
+  trace                Trace           @relation(fields: [traceId], references: [id], onDelete: Cascade)
+
+  @@unique([traceId, externalSpanId])
+  @@index([traceId, startedAt])
 }
 
 model PromptPayload {
@@ -257,6 +293,7 @@ model SpendLedger {
   id            String         @id @default(cuid())
   kind          LedgerKind
   amountUsd     Decimal        @default(0) @db.Decimal(12, 6)
+  sourceEventId String?
   createdAt     DateTime       @default(now())
   metadata      Json?
   hookId        String
@@ -265,6 +302,8 @@ model SpendLedger {
   hook          HookConnection @relation(fields: [hookId], references: [id], onDelete: Cascade)
   llmSession    LLMSession?    @relation(fields: [llmSessionId], references: [id], onDelete: Cascade)
   trace         Trace?         @relation(fields: [traceId], references: [id], onDelete: Cascade)
+
+  @@unique([hookId, sourceEventId, kind])
 }
 
 model Violation {
@@ -272,6 +311,7 @@ model Violation {
   category     String
   eventType    String
   message      String
+  sourceEventId String?
   details      Json?
   createdAt    DateTime       @default(now())
   hookId       String
@@ -280,4 +320,6 @@ model Violation {
   hook         HookConnection @relation(fields: [hookId], references: [id], onDelete: Cascade)
   llmSession   LLMSession?    @relation(fields: [llmSessionId], references: [id], onDelete: Cascade)
   trace        Trace?         @relation(fields: [traceId], references: [id], onDelete: Cascade)
+
+  @@unique([hookId, sourceEventId])
 }

--- a/db/seed.ts
+++ b/db/seed.ts
@@ -1,5 +1,14 @@
 import bcrypt from "bcryptjs";
-import { PrismaClient, PayloadRetention, ProjectRole, TraceStatus, LedgerKind, HookStatus } from "@prisma/client";
+import {
+  PrismaClient,
+  PayloadRetention,
+  ProjectRole,
+  TraceStatus,
+  LedgerKind,
+  HookStatus,
+  TraceSpanKind,
+  TraceSpanStatus,
+} from "@prisma/client";
 
 const prisma = new PrismaClient();
 
@@ -244,6 +253,55 @@ async function main() {
     },
   });
 
+  await prisma.traceSpan.deleteMany({
+    where: { traceId: trace.id },
+  });
+
+  await prisma.traceSpan.createMany({
+    data: [
+      {
+        traceId: trace.id,
+        externalSpanId: "span_seed_session",
+        name: "session",
+        kind: TraceSpanKind.SESSION,
+        status: TraceSpanStatus.COMPLETED,
+        startedAt: new Date("2026-04-04T06:00:00.000Z"),
+        endedAt: new Date("2026-04-04T06:00:08.000Z"),
+        attributes: {
+          sessionId: llmSession.externalSessionId,
+        },
+        eventCount: 2,
+        lastEventAt: new Date("2026-04-04T06:00:08.000Z"),
+      },
+      {
+        traceId: trace.id,
+        externalSpanId: "span_seed_request",
+        externalParentSpanId: "span_seed_session",
+        name: "responses.create",
+        kind: TraceSpanKind.REQUEST,
+        status: TraceSpanStatus.COMPLETED,
+        startedAt: new Date("2026-04-04T06:00:01.000Z"),
+        endedAt: new Date("2026-04-04T06:00:08.000Z"),
+        attributes: {
+          provider: "openai",
+          model: "gpt-4.1-mini",
+          namespace: "responses",
+          methodName: "create",
+          requestId: "seed_request_demo",
+          inputTokens: 120,
+          outputTokens: 80,
+          costUsd: 0.038,
+        },
+        eventCount: 4,
+        lastEventAt: new Date("2026-04-04T06:00:08.000Z"),
+      },
+    ],
+  });
+
+  await prisma.traceEvent.deleteMany({
+    where: { traceDbId: trace.id },
+  });
+
   await prisma.traceEvent.createMany({
     data: [
       {
@@ -252,6 +310,51 @@ async function main() {
         type: "request.started",
         timestamp: new Date("2026-04-04T06:00:01.000Z"),
         data: { provider: "openai", model: "gpt-4.1-mini" },
+        spanData: {
+          id: "span_seed_request",
+          parentId: "span_seed_session",
+          name: "responses.create",
+          kind: "request",
+          status: "running",
+          startedAt: "2026-04-04T06:00:01.000Z",
+        },
+      },
+      {
+        traceDbId: trace.id,
+        externalEventId: "evt_seed_reserved",
+        type: "estimate.reserved",
+        timestamp: new Date("2026-04-04T06:00:01.100Z"),
+        data: { provider: "openai", model: "gpt-4.1-mini", reservedUsd: 0.06 },
+        spanData: {
+          id: "span_seed_request",
+          parentId: "span_seed_session",
+          name: "responses.create",
+          kind: "request",
+          status: "running",
+          startedAt: "2026-04-04T06:00:01.000Z",
+        },
+      },
+      {
+        traceDbId: trace.id,
+        externalEventId: "evt_seed_response",
+        type: "provider.response",
+        timestamp: new Date("2026-04-04T06:00:08.000Z"),
+        data: {
+          provider: "openai",
+          model: "gpt-4.1-mini",
+          inputTokens: 120,
+          outputTokens: 80,
+          costUsd: 0.038,
+        },
+        spanData: {
+          id: "span_seed_request",
+          parentId: "span_seed_session",
+          name: "responses.create",
+          kind: "request",
+          status: "completed",
+          startedAt: "2026-04-04T06:00:01.000Z",
+          endedAt: "2026-04-04T06:00:08.000Z",
+        },
       },
       {
         traceDbId: trace.id,
@@ -259,9 +362,21 @@ async function main() {
         type: "spend.committed",
         timestamp: new Date("2026-04-04T06:00:08.000Z"),
         data: { actualCostUsd: 0.038, releasedUsd: 0.022 },
+        spanData: {
+          id: "span_seed_request",
+          parentId: "span_seed_session",
+          name: "responses.create",
+          kind: "request",
+          status: "completed",
+          startedAt: "2026-04-04T06:00:01.000Z",
+          endedAt: "2026-04-04T06:00:08.000Z",
+        },
       },
     ],
-    skipDuplicates: true,
+  });
+
+  await prisma.spendLedger.deleteMany({
+    where: { traceId: trace.id },
   });
 
   await prisma.spendLedger.createMany({
@@ -270,6 +385,7 @@ async function main() {
         hookId: hook.id,
         llmSessionId: llmSession.id,
         traceId: trace.id,
+        sourceEventId: "evt_seed_reserved",
         kind: LedgerKind.RESERVED,
         amountUsd: 0.06,
       },
@@ -277,6 +393,7 @@ async function main() {
         hookId: hook.id,
         llmSessionId: llmSession.id,
         traceId: trace.id,
+        sourceEventId: "evt_seed_committed",
         kind: LedgerKind.COMMITTED,
         amountUsd: 0.038,
       },
@@ -284,11 +401,11 @@ async function main() {
         hookId: hook.id,
         llmSessionId: llmSession.id,
         traceId: trace.id,
+        sourceEventId: "evt_seed_committed",
         kind: LedgerKind.RELEASED,
         amountUsd: 0.022,
       },
     ],
-    skipDuplicates: true,
   });
 
   console.log("Seed complete", {


### PR DESCRIPTION
## Linked Issue

- Closes #6

## Summary

- extend the Prisma and ingest layer to persist trace spans and derive trace summary state from span plus ledger data
- update seed data for the span model and add trace span helper coverage in the platform package
- replace the flat trace page with a tree and timeline debugger view, payload panels, violations, and live refresh for running traces

## Validation

- [x] `pnpm db:generate`
- [x] `pnpm --filter @captar/platform lint`
- [x] `pnpm --filter @captar/platform test`

## Risk and Rollback

- Risk level: Medium
- Rollback plan: Revert this PR, then keep the SDK span foundation while falling back to the previous flat platform trace rendering

## Screenshots

- [x] No screenshots attached in CLI session
- [x] UI change reviewed locally through build and test coverage

## Stacking Note

- Base branch: `feat/5-sdk-span-tracing-foundation`
- Merge order: `#8` first, then this PR
