### PR TITLE
feat: add dataset core persistence

### DIFF
--- a/.ai/session-handoff.md
+++ b/.ai/session-handoff.md
@@ -4,8 +4,8 @@
 
 - Date: 2026-04-08
 - Umbrella issue: `#3`
-- Split delivery issues: `#4`, `#5`, `#6`
-- Goal: ship the work as multiple issue-linked branches and pull requests instead of one large diff
+- Active milestone issues: `#11`, `#12`, `#13`
+- Goal: ship project-scoped datasets from traces as multiple issue-linked branches and pull requests
 
 ## Current progress
 
@@ -17,9 +17,10 @@
 - GitHub issue templates, PR template, label sync, and branch protection scripts are added
 - Workspace validation passed with `pnpm lint` and `pnpm test`
 - GitHub labels were synchronized and `main` branch protection was applied
+- Dataset milestone issues are created and the first branch is reserved for schema, shared types, and backend helpers
 
 ## Next steps
 
-- Publish `#4` as the repo workflow pull request
-- Publish `#5` as the SDK tracing pull request
-- Publish `#6` as the stacked platform tracing pull request
+- Publish `#11` as the dataset core pull request
+- Stack `#12` for platform dataset workflows on top of `#11`
+- Stack `#13` for repo memory, docs, and extra dataset coverage on top of `#12`

--- a/apps/platform/lib/datasets.ts
+++ b/apps/platform/lib/datasets.ts
@@ -1,0 +1,513 @@
+import type {
+  DatasetFileFormat,
+  DatasetRowRecord,
+  DatasetRowSource,
+  JsonObject,
+  JsonValue,
+  TraceDatasetExportInput,
+} from "@captar/types";
+
+const datasetFormatSet = new Set<DatasetFileFormat>(["json", "jsonl", "csv"]);
+const datasetSourceKindSet = new Set<DatasetRowSource["kind"]>([
+  "trace_export",
+  "file_import",
+]);
+const payloadRetentionSet = new Set<NonNullable<DatasetRowSource["inputRetentionMode"]>>([
+  "redacted",
+  "raw",
+  "none",
+]);
+
+const csvHeaders = [
+  "input",
+  "output",
+  "metadata",
+  "sourceKind",
+  "traceId",
+  "externalTraceId",
+  "spanId",
+  "inputRetentionMode",
+  "outputRetentionMode",
+  "importedFormat",
+] as const;
+
+export function normalizeDatasetRowsFromText(
+  content: string,
+  format: DatasetFileFormat,
+): DatasetRowRecord[] {
+  switch (format) {
+    case "json":
+      return normalizeJsonDatasetRows(content, format);
+    case "jsonl":
+      return normalizeJsonlDatasetRows(content, format);
+    case "csv":
+      return normalizeCsvDatasetRows(content);
+    default:
+      throw new Error(`Unsupported dataset format: ${String(format)}`);
+  }
+}
+
+export function serializeDatasetRowsToText(
+  rows: DatasetRowRecord[],
+  format: DatasetFileFormat,
+): string {
+  switch (format) {
+    case "json":
+      return `${JSON.stringify(rows, null, 2)}\n`;
+    case "jsonl":
+      return rows.map((row) => JSON.stringify(row)).join("\n");
+    case "csv":
+      return serializeDatasetRowsToCsv(rows);
+    default:
+      throw new Error(`Unsupported dataset format: ${String(format)}`);
+  }
+}
+
+export function buildTraceDatasetRow(input: TraceDatasetExportInput): DatasetRowRecord {
+  return {
+    input: input.prompt ?? null,
+    output: input.response ?? null,
+    metadata: input.metadata,
+    source: {
+      kind: "trace_export",
+      traceId: input.traceId,
+      externalTraceId: input.externalTraceId,
+      spanId: input.spanId,
+      inputRetentionMode: input.promptRetentionMode,
+      outputRetentionMode: input.responseRetentionMode,
+    },
+  };
+}
+
+function normalizeJsonDatasetRows(
+  content: string,
+  format: DatasetFileFormat,
+): DatasetRowRecord[] {
+  const parsed = JSON.parse(content) as unknown;
+  const rows =
+    isPlainObject(parsed) && Array.isArray(parsed.rows) ? parsed.rows : Array.isArray(parsed) ? parsed : [parsed];
+
+  return rows.map((row) =>
+    normalizeDatasetRowRecord(row, {
+      kind: "file_import",
+      importedFormat: format,
+    }),
+  );
+}
+
+function normalizeJsonlDatasetRows(
+  content: string,
+  format: DatasetFileFormat,
+): DatasetRowRecord[] {
+  const lines = content
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  return lines.map((line) =>
+    normalizeDatasetRowRecord(JSON.parse(line), {
+      kind: "file_import",
+      importedFormat: format,
+    }),
+  );
+}
+
+function normalizeCsvDatasetRows(content: string): DatasetRowRecord[] {
+  const rows = parseCsv(content);
+  if (!rows.length) {
+    return [];
+  }
+
+  const headerRow = rows[0] ?? [];
+  const dataRows = rows.slice(1);
+  const headers = headerRow.map((header) => header.trim());
+
+  return dataRows
+    .filter((row) => row.some((cell) => cell.trim().length > 0))
+    .map((row) => {
+      const cells = Object.fromEntries(
+        headers.map((header, index) => [header, row[index] ?? ""]),
+      );
+
+      const extraMetadata = normalizeJsonObject(
+        Object.fromEntries(
+          Object.entries(cells)
+            .filter(
+              ([key, value]) =>
+                !csvHeaders.includes(key as (typeof csvHeaders)[number]) &&
+                value.trim(),
+            )
+            .map(([key, value]) => [key, parseCsvValue(value)]),
+        ),
+      );
+
+      const metadata = mergeJsonObjects(
+        normalizeMetadata(
+          cells.metadata?.trim().length ? parseCsvValue(cells.metadata) : undefined,
+        ),
+        extraMetadata,
+      );
+
+      const source = normalizeDatasetSource({
+        kind: cells.sourceKind || undefined,
+        traceId: cells.traceId || undefined,
+        externalTraceId: cells.externalTraceId || undefined,
+        spanId: cells.spanId || undefined,
+        inputRetentionMode: cells.inputRetentionMode || undefined,
+        outputRetentionMode: cells.outputRetentionMode || undefined,
+        importedFormat: cells.importedFormat || undefined,
+      });
+
+      return {
+        input:
+          "input" in cells ? parseCsvValue(cells.input) : normalizeJsonObject(cells),
+        output:
+          "output" in cells && cells.output.trim().length > 0
+            ? parseCsvValue(cells.output)
+            : undefined,
+        metadata,
+        source: source ?? {
+          kind: "file_import",
+          importedFormat: "csv",
+        },
+      };
+    });
+}
+
+function normalizeDatasetRowRecord(
+  value: unknown,
+  defaultSource?: DatasetRowSource,
+): DatasetRowRecord {
+  if (!isPlainObject(value)) {
+    return {
+      input: normalizeJsonValue(value),
+      source: defaultSource,
+    };
+  }
+
+  const explicitShape =
+    "input" in value ||
+    "output" in value ||
+    "metadata" in value ||
+    "source" in value;
+
+  if (!explicitShape) {
+    return {
+      input: normalizeJsonObject(value),
+      source: defaultSource,
+    };
+  }
+
+  const extraMetadata = normalizeJsonObject(
+    Object.fromEntries(
+      Object.entries(value).filter(
+        ([key, entryValue]) =>
+          !["input", "output", "metadata", "source"].includes(key) &&
+          entryValue !== undefined,
+      ),
+    ),
+  );
+
+  return {
+    input: normalizeJsonValue("input" in value ? value.input : null),
+    output:
+      "output" in value ? normalizeJsonValue(value.output ?? null) : undefined,
+    metadata: mergeJsonObjects(
+      normalizeMetadata(value.metadata),
+      extraMetadata,
+    ),
+    source: normalizeDatasetSource(value.source) ?? defaultSource,
+  };
+}
+
+function normalizeMetadata(value: unknown): JsonObject | undefined {
+  if (value == null) {
+    return undefined;
+  }
+
+  if (isPlainObject(value)) {
+    return normalizeJsonObject(value);
+  }
+
+  return {
+    value: normalizeJsonValue(value),
+  };
+}
+
+function normalizeDatasetSource(value: unknown): DatasetRowSource | undefined {
+  if (!isPlainObject(value)) {
+    return undefined;
+  }
+
+  const kind = datasetSourceKindSet.has(
+    value.kind as DatasetRowSource["kind"],
+  )
+    ? (value.kind as DatasetRowSource["kind"])
+    : undefined;
+
+  const importedFormat = datasetFormatSet.has(
+    value.importedFormat as DatasetFileFormat,
+  )
+    ? (value.importedFormat as DatasetFileFormat)
+    : undefined;
+
+  const inputRetentionMode = payloadRetentionSet.has(
+    value.inputRetentionMode as NonNullable<DatasetRowSource["inputRetentionMode"]>,
+  )
+    ? (value.inputRetentionMode as DatasetRowSource["inputRetentionMode"])
+    : undefined;
+
+  const outputRetentionMode = payloadRetentionSet.has(
+    value.outputRetentionMode as NonNullable<DatasetRowSource["outputRetentionMode"]>,
+  )
+    ? (value.outputRetentionMode as DatasetRowSource["outputRetentionMode"])
+    : undefined;
+
+  if (!kind) {
+    return undefined;
+  }
+
+  const source: DatasetRowSource = { kind };
+
+  if (typeof value.traceId === "string") {
+    source.traceId = value.traceId;
+  }
+
+  if (typeof value.externalTraceId === "string") {
+    source.externalTraceId = value.externalTraceId;
+  }
+
+  if (typeof value.spanId === "string") {
+    source.spanId = value.spanId;
+  }
+
+  if (inputRetentionMode) {
+    source.inputRetentionMode = inputRetentionMode;
+  }
+
+  if (outputRetentionMode) {
+    source.outputRetentionMode = outputRetentionMode;
+  }
+
+  if (importedFormat) {
+    source.importedFormat = importedFormat;
+  }
+
+  return source;
+}
+
+function normalizeJsonValue(value: unknown): JsonValue {
+  if (value == null) {
+    return null;
+  }
+
+  if (
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return value;
+  }
+
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => normalizeJsonValue(entry));
+  }
+
+  if (isPlainObject(value)) {
+    return normalizeJsonObject(value);
+  }
+
+  return String(value);
+}
+
+function normalizeJsonObject(value: Record<string, unknown>): JsonObject {
+  return Object.fromEntries(
+    Object.entries(value)
+      .filter(([, entryValue]) => entryValue !== undefined)
+      .map(([key, entryValue]) => [key, normalizeJsonValue(entryValue)]),
+  ) as JsonObject;
+}
+
+function mergeJsonObjects(
+  left?: JsonObject,
+  right?: JsonObject,
+): JsonObject | undefined {
+  if (!left && !right) {
+    return undefined;
+  }
+
+  const merged = {
+    ...(left ?? {}),
+    ...(right ?? {}),
+  };
+
+  return Object.keys(merged).length ? merged : undefined;
+}
+
+function parseCsv(content: string): string[][] {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let cell = "";
+  let inQuotes = false;
+
+  for (let index = 0; index < content.length; index += 1) {
+    const character = content[index];
+    const next = content[index + 1];
+
+    if (character === "\r") {
+      continue;
+    }
+
+    if (inQuotes) {
+      if (character === "\"") {
+        if (next === "\"") {
+          cell += "\"";
+          index += 1;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        cell += character;
+      }
+      continue;
+    }
+
+    if (character === "\"") {
+      inQuotes = true;
+      continue;
+    }
+
+    if (character === ",") {
+      row.push(cell);
+      cell = "";
+      continue;
+    }
+
+    if (character === "\n") {
+      row.push(cell);
+      rows.push(row);
+      row = [];
+      cell = "";
+      continue;
+    }
+
+    cell += character;
+  }
+
+  if (cell.length > 0 || row.length > 0) {
+    row.push(cell);
+    rows.push(row);
+  }
+
+  return rows.filter((rowValue) =>
+    rowValue.some((cellValue) => cellValue.length > 0),
+  );
+}
+
+function parseCsvValue(value: string): JsonValue {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return "";
+  }
+
+  if (trimmed === "null") {
+    return null;
+  }
+
+  if (trimmed === "true") {
+    return true;
+  }
+
+  if (trimmed === "false") {
+    return false;
+  }
+
+  if (/^-?(0|[1-9]\d*)(\.\d+)?$/.test(trimmed)) {
+    return Number(trimmed);
+  }
+
+  if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+    try {
+      return normalizeJsonValue(JSON.parse(trimmed));
+    } catch {
+      return value;
+    }
+  }
+
+  return value;
+}
+
+function serializeDatasetRowsToCsv(rows: DatasetRowRecord[]): string {
+  const lines = [
+    csvHeaders.join(","),
+    ...rows.map((row) =>
+      csvHeaders
+        .map((header) => escapeCsvCell(csvCellForHeader(row, header)))
+        .join(","),
+    ),
+  ];
+
+  return `${lines.join("\n")}\n`;
+}
+
+function csvCellForHeader(
+  row: DatasetRowRecord,
+  header: (typeof csvHeaders)[number],
+): string {
+  switch (header) {
+    case "input":
+      return jsonValueToCsvCell(row.input);
+    case "output":
+      return row.output === undefined ? "" : jsonValueToCsvCell(row.output);
+    case "metadata":
+      return row.metadata ? JSON.stringify(row.metadata) : "";
+    case "sourceKind":
+      return row.source?.kind ?? "";
+    case "traceId":
+      return row.source?.traceId ?? "";
+    case "externalTraceId":
+      return row.source?.externalTraceId ?? "";
+    case "spanId":
+      return row.source?.spanId ?? "";
+    case "inputRetentionMode":
+      return row.source?.inputRetentionMode ?? "";
+    case "outputRetentionMode":
+      return row.source?.outputRetentionMode ?? "";
+    case "importedFormat":
+      return row.source?.importedFormat ?? "";
+    default:
+      return "";
+  }
+}
+
+function jsonValueToCsvCell(value: JsonValue): string {
+  if (value == null) {
+    return "null";
+  }
+
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+
+  return JSON.stringify(value);
+}
+
+function escapeCsvCell(value: string): string {
+  if (value.includes(",") || value.includes("\n") || value.includes("\"")) {
+    return `"${value.replaceAll("\"", "\"\"")}"`;
+  }
+
+  return value;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/apps/platform/lib/platform.ts
+++ b/apps/platform/lib/platform.ts
@@ -1,4 +1,5 @@
 import {
+  DatasetSourceKind,
   HookStatus,
   LedgerKind,
   PayloadRetention,
@@ -6,10 +7,26 @@ import {
   TraceSpanKind,
   TraceSpanStatus,
   TraceStatus,
-  type Prisma,
+  Prisma,
 } from "@prisma/client";
-import type { ExportBatch, TraceSpanSnapshot } from "@captar/types";
+import type {
+  DatasetFileFormat,
+  DatasetRowRecord,
+  DatasetRowSnapshot,
+  DatasetSnapshot,
+  ExportBatch,
+  JsonObject,
+  JsonValue,
+  PayloadRetentionMode,
+  TraceDatasetExportInput,
+  TraceSpanSnapshot,
+} from "@captar/types";
 
+import {
+  buildTraceDatasetRow,
+  normalizeDatasetRowsFromText,
+  serializeDatasetRowsToText,
+} from "./datasets";
 import { prisma } from "./db";
 import { extractPromptContent, extractResponseContent, redactContent } from "./redaction";
 import { summarizeTraceFromSpans } from "./trace-spans";
@@ -32,6 +49,115 @@ function jsonObjectOrUndefined(
   return Object.fromEntries(
     Object.entries(value).filter(([, entryValue]) => entryValue !== undefined),
   ) as Prisma.JsonObject;
+}
+
+function nestedJsonValueToPrisma(value: JsonValue): Prisma.InputJsonValue | null {
+  if (value === null) {
+    return null;
+  }
+
+  if (
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => nestedJsonValueToPrisma(entry)) as Prisma.InputJsonArray;
+  }
+
+  return Object.fromEntries(
+    Object.entries(value)
+      .flatMap(([key, entryValue]) =>
+        entryValue === undefined
+          ? []
+          : [[key, nestedJsonValueToPrisma(entryValue)]],
+      ),
+  ) as Prisma.InputJsonObject;
+}
+
+function requiredJsonValueToPrisma(
+  value: JsonValue,
+): Prisma.InputJsonValue | typeof Prisma.JsonNull {
+  return value === null
+    ? Prisma.JsonNull
+    : (nestedJsonValueToPrisma(value) as Prisma.InputJsonValue);
+}
+
+function optionalJsonValueToPrisma(
+  value: JsonValue | undefined,
+): Prisma.InputJsonValue | typeof Prisma.JsonNull | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  return requiredJsonValueToPrisma(value);
+}
+
+function jsonObjectToPrisma(
+  value: JsonObject | undefined,
+): Prisma.InputJsonObject | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  return nestedJsonValueToPrisma(value) as Prisma.InputJsonObject;
+}
+
+function toPayloadRetentionMode(
+  retentionMode: PayloadRetention | null | undefined,
+): PayloadRetentionMode | undefined {
+  switch (retentionMode) {
+    case PayloadRetention.RAW:
+      return "raw";
+    case PayloadRetention.NONE:
+      return "none";
+    case PayloadRetention.REDACTED:
+      return "redacted";
+    default:
+      return undefined;
+  }
+}
+
+function fromPayloadRetentionMode(
+  retentionMode: PayloadRetentionMode | undefined,
+): PayloadRetention | null {
+  switch (retentionMode) {
+    case "raw":
+      return PayloadRetention.RAW;
+    case "none":
+      return PayloadRetention.NONE;
+    case "redacted":
+      return PayloadRetention.REDACTED;
+    default:
+      return null;
+  }
+}
+
+function toDatasetSourceKind(
+  kind: NonNullable<DatasetRowRecord["source"]>["kind"],
+): DatasetSourceKind {
+  switch (kind) {
+    case "file_import":
+      return DatasetSourceKind.FILE_IMPORT;
+    case "trace_export":
+    default:
+      return DatasetSourceKind.TRACE_EXPORT;
+  }
+}
+
+function fromDatasetSourceKind(
+  kind: DatasetSourceKind,
+): NonNullable<DatasetRowRecord["source"]>["kind"] {
+  switch (kind) {
+    case DatasetSourceKind.FILE_IMPORT:
+      return "file_import";
+    case DatasetSourceKind.TRACE_EXPORT:
+    default:
+      return "trace_export";
+  }
 }
 
 function traceSpanToJson(span: TraceSpanSnapshot | undefined): Prisma.JsonObject | undefined {
@@ -96,6 +222,151 @@ function violationCategoryForEvent(
     default:
       return "workflow";
   }
+}
+
+function toDatasetSnapshot(dataset: {
+  id: string;
+  projectId: string;
+  name: string;
+  description: string | null;
+  rowCount: number;
+  createdAt: Date;
+  updatedAt: Date;
+}): DatasetSnapshot {
+  return {
+    id: dataset.id,
+    projectId: dataset.projectId,
+    name: dataset.name,
+    description: dataset.description ?? undefined,
+    rowCount: dataset.rowCount,
+    createdAt: dataset.createdAt.toISOString(),
+    updatedAt: dataset.updatedAt.toISOString(),
+  };
+}
+
+function toDatasetRowSnapshot(row: {
+  id: string;
+  datasetId: string;
+  position: number;
+  input: Prisma.JsonValue;
+  output: Prisma.JsonValue | null;
+  metadata: Prisma.JsonValue | null;
+  sourceKind: DatasetSourceKind;
+  sourceTraceId: string | null;
+  sourceExternalTraceId: string | null;
+  sourceSpanId: string | null;
+  inputRetentionMode: PayloadRetention | null;
+  outputRetentionMode: PayloadRetention | null;
+  createdAt: Date;
+}): DatasetRowSnapshot {
+  const metadata =
+    row.metadata && typeof row.metadata === "object" && !Array.isArray(row.metadata)
+      ? (row.metadata as JsonObject)
+      : undefined;
+
+  return {
+    id: row.id,
+    datasetId: row.datasetId,
+    position: row.position,
+    input: row.input as JsonValue,
+    output: row.output === null ? undefined : (row.output as JsonValue),
+    metadata,
+    source: {
+      kind: fromDatasetSourceKind(row.sourceKind),
+      traceId: row.sourceTraceId ?? undefined,
+      externalTraceId: row.sourceExternalTraceId ?? undefined,
+      spanId: row.sourceSpanId ?? undefined,
+      inputRetentionMode: toPayloadRetentionMode(row.inputRetentionMode),
+      outputRetentionMode: toPayloadRetentionMode(row.outputRetentionMode),
+    },
+    createdAt: row.createdAt.toISOString(),
+  };
+}
+
+function payloadSnapshotContent(payload: {
+  retentionMode: PayloadRetention;
+  contentRaw: string | null;
+  contentRedacted: string | null;
+} | null): string | null {
+  if (!payload) {
+    return null;
+  }
+
+  switch (payload.retentionMode) {
+    case PayloadRetention.RAW:
+      return payload.contentRaw ?? payload.contentRedacted ?? null;
+    case PayloadRetention.REDACTED:
+      return payload.contentRedacted ?? payload.contentRaw ?? null;
+    case PayloadRetention.NONE:
+    default:
+      return null;
+  }
+}
+
+function buildTraceDatasetExportInput(trace: {
+  id: string;
+  externalTraceId: string;
+  requestId: string | null;
+  provider: string | null;
+  model: string | null;
+  namespace: string | null;
+  methodName: string | null;
+  status: TraceStatus;
+  metadata: Prisma.JsonValue | null;
+  hook: { publicId: string; projectId: string };
+  llmSession: { externalSessionId: string };
+  promptPayload: {
+    retentionMode: PayloadRetention;
+    contentRaw: string | null;
+    contentRedacted: string | null;
+  } | null;
+  responsePayload: {
+    retentionMode: PayloadRetention;
+    contentRaw: string | null;
+    contentRedacted: string | null;
+  } | null;
+  spans: Array<{ externalSpanId: string; kind: TraceSpanKind }>;
+}): TraceDatasetExportInput | null {
+  const prompt = payloadSnapshotContent(trace.promptPayload);
+  const response = payloadSnapshotContent(trace.responsePayload);
+
+  if (prompt == null && response == null) {
+    return null;
+  }
+
+  const traceMetadata =
+    trace.metadata &&
+    typeof trace.metadata === "object" &&
+    !Array.isArray(trace.metadata)
+      ? (trace.metadata as JsonObject)
+      : undefined;
+  const primarySpan =
+    trace.spans.find((span) => span.kind === TraceSpanKind.REQUEST) ?? trace.spans[0];
+
+  const metadata = Object.fromEntries(
+    Object.entries({
+      ...(traceMetadata ? { traceMetadata } : {}),
+      requestId: trace.requestId ?? undefined,
+      provider: trace.provider ?? undefined,
+      model: trace.model ?? undefined,
+      namespace: trace.namespace ?? undefined,
+      methodName: trace.methodName ?? undefined,
+      status: trace.status.toLowerCase(),
+      hookId: trace.hook.publicId,
+      sessionId: trace.llmSession.externalSessionId,
+    }).filter(([, value]) => value !== undefined),
+  ) as JsonObject;
+
+  return {
+    traceId: trace.id,
+    externalTraceId: trace.externalTraceId,
+    spanId: primarySpan?.externalSpanId,
+    prompt,
+    response,
+    promptRetentionMode: toPayloadRetentionMode(trace.promptPayload?.retentionMode),
+    responseRetentionMode: toPayloadRetentionMode(trace.responsePayload?.retentionMode),
+    metadata: Object.keys(metadata).length ? metadata : undefined,
+  };
 }
 
 async function upsertTraceSpanFromEvent(
@@ -403,6 +674,263 @@ export async function getTraceById(traceId: string, userId: string) {
       },
     },
   });
+}
+
+export async function listProjectDatasets(projectId: string, userId: string) {
+  const datasets = await prisma.dataset.findMany({
+    where: {
+      projectId,
+      project: {
+        members: {
+          some: { userId },
+        },
+      },
+    },
+    orderBy: { updatedAt: "desc" },
+  });
+
+  return datasets.map(toDatasetSnapshot);
+}
+
+export async function createProjectDataset(
+  projectId: string,
+  userId: string,
+  input: {
+    name: string;
+    description?: string | null;
+  },
+) {
+  const project = await prisma.project.findFirst({
+    where: {
+      id: projectId,
+      members: {
+        some: { userId },
+      },
+    },
+    select: { id: true },
+  });
+
+  if (!project) {
+    return null;
+  }
+
+  const dataset = await prisma.dataset.create({
+    data: {
+      projectId: project.id,
+      name: input.name.trim(),
+      description: input.description?.trim() || null,
+    },
+  });
+
+  return toDatasetSnapshot(dataset);
+}
+
+export async function getProjectDatasetById(
+  projectId: string,
+  datasetId: string,
+  userId: string,
+) {
+  const dataset = await prisma.dataset.findFirst({
+    where: {
+      id: datasetId,
+      projectId,
+      project: {
+        members: {
+          some: { userId },
+        },
+      },
+    },
+    include: {
+      rows: {
+        orderBy: { position: "asc" },
+      },
+    },
+  });
+
+  if (!dataset) {
+    return null;
+  }
+
+  return {
+    ...toDatasetSnapshot(dataset),
+    rows: dataset.rows.map(toDatasetRowSnapshot),
+  };
+}
+
+export async function appendDatasetRows(
+  projectId: string,
+  datasetId: string,
+  userId: string,
+  rows: DatasetRowRecord[],
+) {
+  if (!rows.length) {
+    return null;
+  }
+
+  return prisma.$transaction(async (transaction) => {
+    const dataset = await transaction.dataset.findFirst({
+      where: {
+        id: datasetId,
+        projectId,
+        project: {
+          members: {
+            some: { userId },
+          },
+        },
+      },
+    });
+
+    if (!dataset) {
+      return null;
+    }
+
+    const nextPosition = dataset.rowCount + 1;
+
+    await transaction.datasetRow.createMany({
+      data: rows.map((row, index) => ({
+        datasetId: dataset.id,
+        position: nextPosition + index,
+        input: requiredJsonValueToPrisma(row.input),
+        output: optionalJsonValueToPrisma(row.output),
+        metadata: jsonObjectToPrisma(row.metadata),
+        sourceKind: toDatasetSourceKind(row.source?.kind ?? "file_import"),
+        sourceTraceId: row.source?.traceId ?? null,
+        sourceExternalTraceId: row.source?.externalTraceId ?? null,
+        sourceSpanId: row.source?.spanId ?? null,
+        inputRetentionMode: fromPayloadRetentionMode(row.source?.inputRetentionMode),
+        outputRetentionMode: fromPayloadRetentionMode(row.source?.outputRetentionMode),
+      })),
+    });
+
+    const updated = await transaction.dataset.update({
+      where: { id: dataset.id },
+      data: {
+        rowCount: {
+          increment: rows.length,
+        },
+      },
+    });
+
+    return toDatasetSnapshot(updated);
+  });
+}
+
+export async function importProjectDatasetRows(
+  projectId: string,
+  datasetId: string,
+  userId: string,
+  format: DatasetFileFormat,
+  content: string,
+) {
+  const rows = normalizeDatasetRowsFromText(content, format);
+  const dataset = await appendDatasetRows(projectId, datasetId, userId, rows);
+
+  if (!dataset) {
+    return null;
+  }
+
+  return {
+    dataset,
+    appendedCount: rows.length,
+  };
+}
+
+export async function exportProjectDataset(
+  projectId: string,
+  datasetId: string,
+  userId: string,
+  format: DatasetFileFormat,
+) {
+  const dataset = await prisma.dataset.findFirst({
+    where: {
+      id: datasetId,
+      projectId,
+      project: {
+        members: {
+          some: { userId },
+        },
+      },
+    },
+    include: {
+      rows: {
+        orderBy: { position: "asc" },
+      },
+    },
+  });
+
+  if (!dataset) {
+    return null;
+  }
+
+  const snapshots = dataset.rows.map(toDatasetRowSnapshot);
+  return {
+    dataset: toDatasetSnapshot(dataset),
+    rows: snapshots,
+    content: serializeDatasetRowsToText(snapshots, format),
+    fileName: `${slugify(dataset.name || "dataset")}.${format}`,
+  };
+}
+
+export async function appendTraceToDataset(
+  projectId: string,
+  datasetId: string,
+  traceId: string,
+  userId: string,
+) {
+  const trace = await prisma.trace.findFirst({
+    where: {
+      id: traceId,
+      hook: {
+        projectId,
+        project: {
+          members: {
+            some: { userId },
+          },
+        },
+      },
+    },
+    include: {
+      hook: true,
+      llmSession: true,
+      promptPayload: true,
+      responsePayload: true,
+      spans: {
+        orderBy: { startedAt: "asc" },
+      },
+    },
+  });
+
+  if (!trace) {
+    return null;
+  }
+
+  const exportInput = buildTraceDatasetExportInput(trace);
+  if (!exportInput) {
+    return null;
+  }
+
+  const row = buildTraceDatasetRow(exportInput);
+  const dataset = await appendDatasetRows(projectId, datasetId, userId, [row]);
+
+  if (!dataset) {
+    return null;
+  }
+
+  const insertedRow = await prisma.datasetRow.findFirst({
+    where: {
+      datasetId,
+      position: dataset.rowCount,
+    },
+  });
+
+  if (!insertedRow) {
+    return null;
+  }
+
+  return {
+    dataset,
+    row: toDatasetRowSnapshot(insertedRow),
+  };
 }
 
 function findOrCreateTraceState(

--- a/apps/platform/test/datasets.test.ts
+++ b/apps/platform/test/datasets.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildTraceDatasetRow,
+  normalizeDatasetRowsFromText,
+  serializeDatasetRowsToText,
+} from "../lib/datasets";
+
+describe("dataset helpers", () => {
+  it("builds a trace-derived dataset row with lineage and retention metadata", () => {
+    const row = buildTraceDatasetRow({
+      traceId: "trace_db_1",
+      externalTraceId: "trace_ext_1",
+      spanId: "span_req_1",
+      prompt: "Summarize the ticket.",
+      response: "The customer needs a refund.",
+      promptRetentionMode: "redacted",
+      responseRetentionMode: "raw",
+      metadata: {
+        provider: "openai",
+        model: "gpt-4.1-mini",
+      },
+    });
+
+    expect(row).toEqual({
+      input: "Summarize the ticket.",
+      output: "The customer needs a refund.",
+      metadata: {
+        provider: "openai",
+        model: "gpt-4.1-mini",
+      },
+      source: {
+        kind: "trace_export",
+        traceId: "trace_db_1",
+        externalTraceId: "trace_ext_1",
+        spanId: "span_req_1",
+        inputRetentionMode: "redacted",
+        outputRetentionMode: "raw",
+      },
+    });
+  });
+
+  it("normalizes json imports into the shared row shape", () => {
+    const rows = normalizeDatasetRowsFromText(
+      JSON.stringify({
+        rows: [
+          {
+            input: { prompt: "How many orders are late?" },
+            output: { answer: 12 },
+            metadata: { split: "train" },
+            priority: "high",
+          },
+          "plain text input",
+        ],
+      }),
+      "json",
+    );
+
+    expect(rows).toEqual([
+      {
+        input: { prompt: "How many orders are late?" },
+        output: { answer: 12 },
+        metadata: {
+          split: "train",
+          priority: "high",
+        },
+        source: {
+          kind: "file_import",
+          importedFormat: "json",
+        },
+      },
+      {
+        input: "plain text input",
+        source: {
+          kind: "file_import",
+          importedFormat: "json",
+        },
+      },
+    ]);
+  });
+
+  it("normalizes jsonl imports and keeps provided source metadata", () => {
+    const rows = normalizeDatasetRowsFromText(
+      [
+        JSON.stringify({
+          input: "Prompt A",
+          output: "Answer A",
+          source: {
+            kind: "trace_export",
+            traceId: "trace_db_a",
+            externalTraceId: "trace_ext_a",
+          },
+        }),
+        JSON.stringify({
+          input: "Prompt B",
+        }),
+      ].join("\n"),
+      "jsonl",
+    );
+
+    expect(rows).toEqual([
+      {
+        input: "Prompt A",
+        output: "Answer A",
+        source: {
+          kind: "trace_export",
+          traceId: "trace_db_a",
+          externalTraceId: "trace_ext_a",
+        },
+      },
+      {
+        input: "Prompt B",
+        source: {
+          kind: "file_import",
+          importedFormat: "jsonl",
+        },
+      },
+    ]);
+  });
+
+  it("normalizes csv imports with extra columns folded into metadata", () => {
+    const rows = normalizeDatasetRowsFromText(
+      [
+        "input,output,metadata,label,sourceKind,traceId,externalTraceId,inputRetentionMode",
+        "\"Summarize case\",\"Refund approved\",\"{\"\"channel\"\":\"\"email\"\"}\",priority,trace_export,trace_db_2,trace_ext_2,redacted",
+      ].join("\n"),
+      "csv",
+    );
+
+    expect(rows).toEqual([
+      {
+        input: "Summarize case",
+        output: "Refund approved",
+        metadata: {
+          channel: "email",
+          label: "priority",
+        },
+        source: {
+          kind: "trace_export",
+          traceId: "trace_db_2",
+          externalTraceId: "trace_ext_2",
+          inputRetentionMode: "redacted",
+        },
+      },
+    ]);
+  });
+
+  it("serializes dataset rows to csv with source fields and metadata", () => {
+    const csv = serializeDatasetRowsToText(
+      [
+        {
+          input: { prompt: "What changed?" },
+          output: "Policy version 2",
+          metadata: { split: "eval" },
+          source: {
+            kind: "trace_export",
+            traceId: "trace_db_3",
+            externalTraceId: "trace_ext_3",
+            spanId: "span_3",
+            inputRetentionMode: "redacted",
+            outputRetentionMode: "raw",
+          },
+        },
+      ],
+      "csv",
+    );
+
+    expect(csv).toContain(
+      "input,output,metadata,sourceKind,traceId,externalTraceId,spanId,inputRetentionMode,outputRetentionMode,importedFormat",
+    );
+    expect(csv).toContain("\"{\"\"prompt\"\":\"\"What changed?\"\"}\"");
+    expect(csv).toContain("trace_export");
+    expect(csv).toContain("trace_db_3");
+  });
+});

--- a/db/prisma/schema.prisma
+++ b/db/prisma/schema.prisma
@@ -51,6 +51,11 @@ enum LedgerKind {
   RELEASED
 }
 
+enum DatasetSourceKind {
+  TRACE_EXPORT
+  FILE_IMPORT
+}
+
 model User {
   id            String          @id @default(cuid())
   name          String?
@@ -112,6 +117,7 @@ model Project {
   members     ProjectMember[]
   hooks       HookConnection[]
   sessions    LLMSession[]
+  datasets    Dataset[]
 }
 
 model ProjectMember {
@@ -225,6 +231,7 @@ model Trace {
   responsePayload  ResponsePayload?
   spendEntries     SpendLedger[]
   violations       Violation[]
+  datasetRows      DatasetRow[]   @relation("TraceDatasetRows")
 
   @@unique([hookId, externalTraceId])
 }
@@ -263,6 +270,43 @@ model TraceSpan {
 
   @@unique([traceId, externalSpanId])
   @@index([traceId, startedAt])
+}
+
+model Dataset {
+  id          String       @id @default(cuid())
+  name        String
+  description String?
+  rowCount    Int          @default(0)
+  createdAt   DateTime     @default(now())
+  updatedAt   DateTime     @updatedAt
+  projectId   String
+  project     Project      @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  rows        DatasetRow[]
+
+  @@unique([projectId, name])
+  @@index([projectId, createdAt])
+}
+
+model DatasetRow {
+  id                  String            @id @default(cuid())
+  position            Int
+  input               Json
+  output              Json?
+  metadata            Json?
+  sourceKind          DatasetSourceKind
+  sourceTraceId       String?
+  sourceExternalTraceId String?
+  sourceSpanId        String?
+  inputRetentionMode  PayloadRetention?
+  outputRetentionMode PayloadRetention?
+  createdAt           DateTime          @default(now())
+  datasetId           String
+  dataset             Dataset           @relation(fields: [datasetId], references: [id], onDelete: Cascade)
+  sourceTrace         Trace?            @relation("TraceDatasetRows", fields: [sourceTraceId], references: [id], onDelete: SetNull)
+
+  @@unique([datasetId, position])
+  @@index([datasetId, createdAt])
+  @@index([sourceTraceId])
 }
 
 model PromptPayload {

--- a/packages/ts/types/src/index.ts
+++ b/packages/ts/types/src/index.ts
@@ -35,6 +35,63 @@ export interface SessionPolicy {
 
 export type PayloadRetentionMode = "redacted" | "raw" | "none";
 
+export type JsonPrimitive = string | number | boolean | null;
+
+export type JsonValue = JsonPrimitive | JsonObject | JsonValue[];
+
+export interface JsonObject {
+  [key: string]: JsonValue | undefined;
+}
+
+export type DatasetFileFormat = "json" | "jsonl" | "csv";
+
+export type DatasetSourceKind = "trace_export" | "file_import";
+
+export interface DatasetRowSource {
+  kind: DatasetSourceKind;
+  traceId?: string;
+  externalTraceId?: string;
+  spanId?: string;
+  inputRetentionMode?: PayloadRetentionMode;
+  outputRetentionMode?: PayloadRetentionMode;
+  importedFormat?: DatasetFileFormat;
+}
+
+export interface DatasetRowRecord {
+  input: JsonValue;
+  output?: JsonValue;
+  metadata?: JsonObject;
+  source?: DatasetRowSource;
+}
+
+export interface DatasetSnapshot {
+  id: string;
+  projectId: string;
+  name: string;
+  description?: string;
+  rowCount: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface DatasetRowSnapshot extends DatasetRowRecord {
+  id: string;
+  datasetId: string;
+  position: number;
+  createdAt: string;
+}
+
+export interface TraceDatasetExportInput {
+  traceId: string;
+  externalTraceId: string;
+  spanId?: string;
+  prompt?: string | null;
+  response?: string | null;
+  promptRetentionMode?: PayloadRetentionMode;
+  responseRetentionMode?: PayloadRetentionMode;
+  metadata?: JsonObject;
+}
+
 export interface ControlPlaneProject {
   id: string;
   name: string;


### PR DESCRIPTION
## Linked Issue

- Closes #11

## Summary

- add project-scoped dataset persistence with `Dataset` and append-only `DatasetRow` models in Prisma
- add shared dataset contracts in `@captar/types` for normalized rows, file formats, snapshots, and trace export input
- add backend dataset helpers for create, list, load, append, import normalization, export serialization, and trace-to-dataset row creation
- add dataset helper tests plus a session handoff update for the active milestone

## Validation

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] Additional validation noted below

Additional validation:
- [x] `pnpm db:generate`

## Risk and Rollback

- Risk level: medium, because this adds new persistence models and shared data contracts that later platform routes will depend on
- Rollback plan: revert this branch before the platform workflow PR lands, then regenerate Prisma client to return to the pre-dataset schema

## Screenshots

- [ ] UI change with screenshots attached
- [x] No UI change
