### PR TITLE
feat: add platform dataset workflows

### DIFF
--- a/apps/platform/app/api/projects/[projectId]/datasets/[datasetId]/export/route.ts
+++ b/apps/platform/app/api/projects/[projectId]/datasets/[datasetId]/export/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from "next/server";
+
+import type { DatasetFileFormat } from "@captar/types";
+
+import { auth } from "../../../../../../../auth";
+import { exportProjectDataset } from "../../../../../../../lib/platform";
+
+const contentTypeByFormat: Record<DatasetFileFormat, string> = {
+  json: "application/json; charset=utf-8",
+  jsonl: "application/x-ndjson; charset=utf-8",
+  csv: "text/csv; charset=utf-8",
+};
+
+function parseFormat(value: string | null): DatasetFileFormat | null {
+  if (value === "json" || value === "jsonl" || value === "csv") {
+    return value;
+  }
+
+  return null;
+}
+
+export async function GET(
+  request: Request,
+  context: { params: Promise<{ projectId: string; datasetId: string }> },
+) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { projectId, datasetId } = await context.params;
+  const url = new URL(request.url);
+  const format = parseFormat(url.searchParams.get("format")) ?? "jsonl";
+
+  const result = await exportProjectDataset(
+    projectId,
+    datasetId,
+    session.user.id,
+    format,
+  );
+
+  if (!result) {
+    return NextResponse.json({ error: "Dataset not found." }, { status: 404 });
+  }
+
+  return new NextResponse(result.content, {
+    headers: {
+      "content-type": contentTypeByFormat[format],
+      "content-disposition": `attachment; filename=\"${result.fileName}\"`,
+    },
+  });
+}

--- a/apps/platform/app/api/projects/[projectId]/datasets/[datasetId]/import/route.ts
+++ b/apps/platform/app/api/projects/[projectId]/datasets/[datasetId]/import/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from "next/server";
+
+import type { DatasetFileFormat } from "@captar/types";
+
+import { auth } from "../../../../../../../auth";
+import { inferDatasetFileFormat } from "../../../../../../../lib/datasets";
+import { importProjectDatasetRows } from "../../../../../../../lib/platform";
+
+export async function POST(
+  request: Request,
+  context: { params: Promise<{ projectId: string; datasetId: string }> },
+) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { projectId, datasetId } = await context.params;
+  const formData = await request.formData();
+  const file = formData.get("file");
+  const formatInput = formData.get("format");
+
+  if (!(file instanceof File)) {
+    return NextResponse.json({ error: "Dataset file is required." }, { status: 400 });
+  }
+
+  const inferredFormat =
+    typeof formatInput === "string" && formatInput.length
+      ? (formatInput as DatasetFileFormat)
+      : inferDatasetFileFormat(file.name);
+
+  if (!inferredFormat) {
+    return NextResponse.json(
+      { error: "Could not determine dataset file format." },
+      { status: 400 },
+    );
+  }
+
+  const result = await importProjectDatasetRows(
+    projectId,
+    datasetId,
+    session.user.id,
+    inferredFormat,
+    await file.text(),
+  );
+
+  if (!result) {
+    return NextResponse.json({ error: "Dataset not found." }, { status: 404 });
+  }
+
+  return NextResponse.json(result);
+}

--- a/apps/platform/app/api/projects/[projectId]/datasets/[datasetId]/trace-export/route.ts
+++ b/apps/platform/app/api/projects/[projectId]/datasets/[datasetId]/trace-export/route.ts
@@ -1,0 +1,69 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import { auth } from "../../../../../../../auth";
+import { appendTraceToDataset, getTraceById } from "../../../../../../../lib/platform";
+
+const traceExportSchema = z.object({
+  traceId: z.string().min(1),
+});
+
+function traceHasPayloadSnapshot(trace: {
+  promptPayload?: {
+    contentRaw?: string | null;
+    contentRedacted?: string | null;
+  } | null;
+  responsePayload?: {
+    contentRaw?: string | null;
+    contentRedacted?: string | null;
+  } | null;
+}) {
+  return Boolean(
+    trace.promptPayload?.contentRaw ??
+      trace.promptPayload?.contentRedacted ??
+      trace.responsePayload?.contentRaw ??
+      trace.responsePayload?.contentRedacted,
+  );
+}
+
+export async function POST(
+  request: Request,
+  context: { params: Promise<{ projectId: string; datasetId: string }> },
+) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { projectId, datasetId } = await context.params;
+  const body = await request.json();
+  const parsed = traceExportSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid trace export input." }, { status: 400 });
+  }
+
+  const trace = await getTraceById(parsed.data.traceId, session.user.id);
+  if (!trace || trace.hook.projectId !== projectId) {
+    return NextResponse.json({ error: "Trace not found." }, { status: 404 });
+  }
+
+  if (!traceHasPayloadSnapshot(trace)) {
+    return NextResponse.json(
+      { error: "No retained prompt or response payload is available for this trace." },
+      { status: 400 },
+    );
+  }
+
+  const result = await appendTraceToDataset(
+    projectId,
+    datasetId,
+    trace.id,
+    session.user.id,
+  );
+
+  if (!result) {
+    return NextResponse.json({ error: "Dataset not found." }, { status: 404 });
+  }
+
+  return NextResponse.json(result);
+}

--- a/apps/platform/app/api/projects/[projectId]/datasets/route.ts
+++ b/apps/platform/app/api/projects/[projectId]/datasets/route.ts
@@ -1,0 +1,69 @@
+import { NextResponse } from "next/server";
+import { Prisma } from "@prisma/client";
+import { z } from "zod";
+
+import { auth } from "../../../../../auth";
+import {
+  createProjectDataset,
+  getProjectById,
+  listProjectDatasets,
+} from "../../../../../lib/platform";
+
+const datasetSchema = z.object({
+  name: z.string().min(2).max(80),
+  description: z.string().max(240).optional(),
+});
+
+export async function GET(
+  _request: Request,
+  context: { params: Promise<{ projectId: string }> },
+) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { projectId } = await context.params;
+  const project = await getProjectById(projectId, session.user.id);
+  if (!project) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  const datasets = await listProjectDatasets(projectId, session.user.id);
+  return NextResponse.json({ datasets });
+}
+
+export async function POST(
+  request: Request,
+  context: { params: Promise<{ projectId: string }> },
+) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { projectId } = await context.params;
+  const body = await request.json();
+  const parsed = datasetSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid dataset input" }, { status: 400 });
+  }
+
+  try {
+    const dataset = await createProjectDataset(projectId, session.user.id, parsed.data);
+    if (!dataset) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({ dataset });
+  } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") {
+      return NextResponse.json(
+        { error: "A dataset with this name already exists in the project." },
+        { status: 409 },
+      );
+    }
+
+    throw error;
+  }
+}

--- a/apps/platform/app/projects/[projectId]/datasets/[datasetId]/page.tsx
+++ b/apps/platform/app/projects/[projectId]/datasets/[datasetId]/page.tsx
@@ -1,0 +1,198 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import type { JsonValue } from "@captar/types";
+
+import { AppShell } from "../../../../../components/app-shell";
+import { DatasetImportForm } from "../../../../../components/dataset-import-form";
+import { Badge } from "../../../../../components/ui/badge";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../../../../../components/ui/card";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../../../../../components/ui/table";
+import { requireUser } from "../../../../../lib/auth-guard";
+import { getProjectById, getProjectDatasetById } from "../../../../../lib/platform";
+
+export const dynamic = "force-dynamic";
+
+export default async function DatasetDetailPage({
+  params,
+}: {
+  params: Promise<{ projectId: string; datasetId: string }>;
+}) {
+  const user = await requireUser();
+  const { projectId, datasetId } = await params;
+  const [project, dataset] = await Promise.all([
+    getProjectById(projectId, user.id),
+    getProjectDatasetById(projectId, datasetId, user.id),
+  ]);
+
+  if (!project || !dataset) {
+    notFound();
+  }
+
+  return (
+    <AppShell userName={user.email}>
+      <div className="grid gap-6">
+        <Card>
+          <CardHeader className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+            <div className="space-y-2">
+              <div className="flex items-center gap-2">
+                <CardTitle>{dataset.name}</CardTitle>
+                <Badge>{dataset.rowCount} rows</Badge>
+              </div>
+              <CardDescription>
+                Dataset in project{" "}
+                <Link
+                  className="text-cyan-300 hover:text-cyan-200"
+                  href={`/projects/${project.id}`}
+                >
+                  {project.name}
+                </Link>
+              </CardDescription>
+              <p className="text-sm text-slate-400">
+                {dataset.description ?? "No description yet."}
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-3">
+              <DatasetExportLink
+                href={`/api/projects/${project.id}/datasets/${dataset.id}/export?format=json`}
+                label="Export JSON"
+              />
+              <DatasetExportLink
+                href={`/api/projects/${project.id}/datasets/${dataset.id}/export?format=jsonl`}
+                label="Export JSONL"
+              />
+              <DatasetExportLink
+                href={`/api/projects/${project.id}/datasets/${dataset.id}/export?format=csv`}
+                label="Export CSV"
+              />
+            </div>
+          </CardHeader>
+          <CardContent className="grid gap-4 md:grid-cols-3">
+            <MetricCard label="Rows" value={String(dataset.rowCount)} />
+            <MetricCard label="Created" value={formatTimestamp(dataset.createdAt)} />
+            <MetricCard label="Updated" value={formatTimestamp(dataset.updatedAt)} />
+          </CardContent>
+        </Card>
+
+        <div className="grid gap-6 xl:grid-cols-[380px_minmax(0,1fr)]">
+          <DatasetImportForm projectId={project.id} datasetId={dataset.id} />
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Dataset rows</CardTitle>
+              <CardDescription>
+                Rows stay append-only in v1 so trace exports and file imports remain auditable.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              {dataset.rows.length ? (
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>#</TableHead>
+                      <TableHead>Input</TableHead>
+                      <TableHead>Output</TableHead>
+                      <TableHead>Source</TableHead>
+                      <TableHead>Retention</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {dataset.rows.map((row) => (
+                      <TableRow key={row.id}>
+                        <TableCell className="font-mono text-xs">{row.position}</TableCell>
+                        <TableCell>
+                          <RowPayload value={row.input} />
+                        </TableCell>
+                        <TableCell>
+                          <RowPayload value={row.output ?? null} emptyLabel="No output" />
+                        </TableCell>
+                        <TableCell>
+                          <div className="space-y-2 text-sm text-slate-300">
+                            <Badge>{row.source?.kind ?? "file_import"}</Badge>
+                            {row.source?.traceId ? (
+                              <Link
+                                className="block text-cyan-300 hover:text-cyan-200"
+                                href={`/traces/${row.source.traceId}`}
+                              >
+                                Trace {row.source.externalTraceId ?? row.source.traceId}
+                              </Link>
+                            ) : (
+                              <p>Imported from file</p>
+                            )}
+                            {row.metadata ? (
+                              <pre className="overflow-x-auto rounded-lg border border-slate-800 bg-slate-950 p-2 text-xs text-slate-400">
+                                {JSON.stringify(row.metadata, null, 2)}
+                              </pre>
+                            ) : null}
+                          </div>
+                        </TableCell>
+                        <TableCell>
+                          <div className="space-y-2 text-sm text-slate-300">
+                            <p>Input: {row.source?.inputRetentionMode ?? "n/a"}</p>
+                            <p>Output: {row.source?.outputRetentionMode ?? "n/a"}</p>
+                          </div>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              ) : (
+                <div className="rounded-xl border border-dashed border-slate-700 bg-slate-950/60 p-6 text-sm text-slate-400">
+                  No rows yet. Import a file or export a trace into this dataset.
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </AppShell>
+  );
+}
+
+function DatasetExportLink({
+  href,
+  label,
+}: {
+  href: string;
+  label: string;
+}) {
+  return (
+    <a
+      className="inline-flex items-center rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 transition hover:border-cyan-400/40 hover:text-cyan-200"
+      href={href}
+    >
+      {label}
+    </a>
+  );
+}
+
+function MetricCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-xl border border-slate-800 bg-slate-900/60 p-4">
+      <p className="text-sm text-slate-400">{label}</p>
+      <p className="text-lg font-semibold">{value}</p>
+    </div>
+  );
+}
+
+function RowPayload({
+  value,
+  emptyLabel = "No value",
+}: {
+  value: JsonValue | null;
+  emptyLabel?: string;
+}) {
+  if (value == null) {
+    return <p className="text-sm text-slate-500">{emptyLabel}</p>;
+  }
+
+  return (
+    <pre className="max-w-[320px] overflow-x-auto whitespace-pre-wrap rounded-lg border border-slate-800 bg-slate-950 p-3 text-xs text-slate-200">
+      {typeof value === "string" ? value : JSON.stringify(value, null, 2)}
+    </pre>
+  );
+}
+
+function formatTimestamp(value: string) {
+  return new Date(value).toISOString();
+}

--- a/apps/platform/app/projects/[projectId]/datasets/page.tsx
+++ b/apps/platform/app/projects/[projectId]/datasets/page.tsx
@@ -1,0 +1,101 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import { AppShell } from "../../../../components/app-shell";
+import { DatasetCreateForm } from "../../../../components/dataset-create-form";
+import { Badge } from "../../../../components/ui/badge";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../../../../components/ui/card";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../../../../components/ui/table";
+import { requireUser } from "../../../../lib/auth-guard";
+import { getProjectById, listProjectDatasets } from "../../../../lib/platform";
+
+export const dynamic = "force-dynamic";
+
+export default async function ProjectDatasetsPage({
+  params,
+}: {
+  params: Promise<{ projectId: string }>;
+}) {
+  const user = await requireUser();
+  const { projectId } = await params;
+  const [project, datasets] = await Promise.all([
+    getProjectById(projectId, user.id),
+    listProjectDatasets(projectId, user.id),
+  ]);
+
+  if (!project) {
+    notFound();
+  }
+
+  return (
+    <AppShell userName={user.email}>
+      <div className="grid gap-6 xl:grid-cols-[380px_minmax(0,1fr)]">
+        <DatasetCreateForm projectId={project.id} />
+
+        <div className="grid gap-6">
+          <Card>
+            <CardHeader className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+              <div className="space-y-2">
+                <div className="flex items-center gap-2">
+                  <CardTitle>Project datasets</CardTitle>
+                  <Badge>{project._count.datasets}</Badge>
+                </div>
+                <CardDescription>
+                  Reusable rows exported from traces or appended from files for project{" "}
+                  <span className="font-medium text-slate-200">{project.name}</span>.
+                </CardDescription>
+              </div>
+              <Link
+                className="text-sm text-cyan-300 hover:text-cyan-200"
+                href={`/projects/${project.id}`}
+              >
+                Back to project
+              </Link>
+            </CardHeader>
+            <CardContent>
+              {datasets.length ? (
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Name</TableHead>
+                      <TableHead>Description</TableHead>
+                      <TableHead>Rows</TableHead>
+                      <TableHead>Updated</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {datasets.map((dataset) => (
+                      <TableRow key={dataset.id}>
+                        <TableCell>
+                          <Link
+                            className="font-medium text-cyan-300 hover:text-cyan-200"
+                            href={`/projects/${project.id}/datasets/${dataset.id}`}
+                          >
+                            {dataset.name}
+                          </Link>
+                        </TableCell>
+                        <TableCell className="text-slate-300">
+                          {dataset.description ?? "No description"}
+                        </TableCell>
+                        <TableCell>{dataset.rowCount}</TableCell>
+                        <TableCell>{formatTimestamp(dataset.updatedAt)}</TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              ) : (
+                <div className="rounded-xl border border-dashed border-slate-700 bg-slate-950/60 p-6 text-sm text-slate-400">
+                  No datasets yet. Create one and start exporting traces into it.
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </AppShell>
+  );
+}
+
+function formatTimestamp(value: string) {
+  return new Date(value).toISOString();
+}

--- a/apps/platform/app/projects/[projectId]/page.tsx
+++ b/apps/platform/app/projects/[projectId]/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { Activity, FolderKanban, ShieldCheck, Wallet } from "lucide-react";
+import { Activity, Database, FolderKanban, ShieldCheck, Wallet } from "lucide-react";
 
 import { AppShell } from "../../../components/app-shell";
 import { HookCreateDialog } from "../../../components/hook-create-dialog";
@@ -56,8 +56,8 @@ export default async function ProjectDetailPage({
               <p className="text-2xl font-semibold">{project.hooks.length}</p>
             </div>
             <div className="rounded-xl border border-slate-800 bg-slate-900/60 p-4">
-              <p className="text-sm text-slate-400">Owner controls</p>
-              <p className="text-2xl font-semibold">Ready</p>
+              <p className="text-sm text-slate-400">Datasets</p>
+              <p className="text-2xl font-semibold">{project._count.datasets}</p>
             </div>
           </CardContent>
         </Card>
@@ -116,6 +116,54 @@ export default async function ProjectDetailPage({
           <div className="grid gap-4">
             <Card>
               <CardHeader>
+                <div className="flex items-start justify-between gap-4">
+                  <div>
+                    <CardTitle>Datasets</CardTitle>
+                    <CardDescription>
+                      Export traces into reusable project-scoped rows.
+                    </CardDescription>
+                  </div>
+                  <Link
+                    className="text-sm text-cyan-300 hover:text-cyan-200"
+                    href={`/projects/${project.id}/datasets`}
+                  >
+                    Open datasets
+                  </Link>
+                </div>
+              </CardHeader>
+              <CardContent className="space-y-3 text-sm text-slate-300">
+                {project.datasets.length ? (
+                  project.datasets.map((dataset) => (
+                    <div
+                      key={dataset.id}
+                      className="rounded-xl border border-slate-800 bg-slate-900/60 p-3"
+                    >
+                      <div className="flex items-start justify-between gap-4">
+                        <div>
+                          <Link
+                            className="font-medium text-cyan-300 hover:text-cyan-200"
+                            href={`/projects/${project.id}/datasets/${dataset.id}`}
+                          >
+                            {dataset.name}
+                          </Link>
+                          <p className="mt-1 text-xs text-slate-400">
+                            {dataset.description ?? "Trace exports and file imports."}
+                          </p>
+                        </div>
+                        <Badge>{dataset.rowCount} rows</Badge>
+                      </div>
+                    </div>
+                  ))
+                ) : (
+                  <div className="rounded-xl border border-dashed border-slate-700 bg-slate-950/60 p-4 text-slate-400">
+                    No datasets yet. Export traces or import files from the dataset page.
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
                 <CardTitle>What this project manages</CardTitle>
               </CardHeader>
               <CardContent className="space-y-4 text-sm text-slate-300">
@@ -130,6 +178,10 @@ export default async function ProjectDetailPage({
                 <div className="flex items-start gap-3">
                   <Wallet className="mt-0.5 h-4 w-4 text-cyan-300" />
                   <p>Spend is tracked from reserve to commit so budget enforcement stays visible in one place.</p>
+                </div>
+                <div className="flex items-start gap-3">
+                  <Database className="mt-0.5 h-4 w-4 text-cyan-300" />
+                  <p>Datasets stay project-scoped so traces can become reusable rows before evals land.</p>
                 </div>
                 <div className="flex items-start gap-3">
                   <ShieldCheck className="mt-0.5 h-4 w-4 text-cyan-300" />

--- a/apps/platform/app/traces/[traceId]/page.tsx
+++ b/apps/platform/app/traces/[traceId]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from "next/navigation";
 
 import { AppShell } from "../../../components/app-shell";
+import { TraceDatasetExportCard } from "../../../components/trace-dataset-export-card";
 import { TraceAutoRefresh } from "../../../components/trace-auto-refresh";
 import { Badge } from "../../../components/ui/badge";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../../../components/ui/card";
@@ -8,7 +9,7 @@ import { Separator } from "../../../components/ui/separator";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "../../../components/ui/tabs";
 import { requireUser } from "../../../lib/auth-guard";
 import { buildTraceSpanTree, buildTraceTimeline, flattenTraceSpanTree, summarizeTraceFromSpans, type TraceSpanNode, type TraceTimelineItem } from "../../../lib/trace-spans";
-import { getTraceById } from "../../../lib/platform";
+import { getTraceById, listProjectDatasets } from "../../../lib/platform";
 
 export const dynamic = "force-dynamic";
 
@@ -24,6 +25,8 @@ export default async function TracePage({
   if (!trace) {
     notFound();
   }
+
+  const datasets = await listProjectDatasets(trace.hook.projectId, user.id);
 
   const summary = summarizeTraceFromSpans(trace.spans, trace.spendEntries);
   const spanTree = buildTraceSpanTree(trace.spans);
@@ -183,6 +186,17 @@ export default async function TracePage({
               </CardContent>
             </Card>
 
+            <TraceDatasetExportCard
+              projectId={trace.hook.projectId}
+              traceId={trace.id}
+              datasets={datasets.map((dataset) => ({
+                id: dataset.id,
+                name: dataset.name,
+                rowCount: dataset.rowCount,
+              }))}
+              disabledReason={datasetExportDisabledReason(trace)}
+            />
+
             <Card>
               <CardHeader>
                 <CardTitle>Prompt Payload</CardTitle>
@@ -317,4 +331,28 @@ function formatDuration(value?: number) {
     return `${value}ms`;
   }
   return `${(value / 1000).toFixed(2)}s`;
+}
+
+function datasetExportDisabledReason(trace: {
+  promptPayload?: {
+    contentRaw?: string | null;
+    contentRedacted?: string | null;
+  } | null;
+  responsePayload?: {
+    contentRaw?: string | null;
+    contentRedacted?: string | null;
+  } | null;
+}) {
+  const prompt =
+    trace.promptPayload?.contentRedacted ?? trace.promptPayload?.contentRaw ?? null;
+  const response =
+    trace.responsePayload?.contentRedacted ??
+    trace.responsePayload?.contentRaw ??
+    null;
+
+  if (prompt == null && response == null) {
+    return "No retained prompt or response payload is available for this trace.";
+  }
+
+  return undefined;
 }

--- a/apps/platform/components/dataset-create-form.tsx
+++ b/apps/platform/components/dataset-create-form.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+import { Button } from "./ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "./ui/card";
+import { Input } from "./ui/input";
+import { Label } from "./ui/label";
+import { Textarea } from "./ui/textarea";
+
+export function DatasetCreateForm({ projectId }: { projectId: string }) {
+  const router = useRouter();
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Create dataset</CardTitle>
+        <CardDescription>
+          Capture reusable rows from traces or file imports without leaving the project.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor="dataset-name">Name</Label>
+          <Input
+            id="dataset-name"
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            placeholder="refund-escalations"
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="dataset-description">Description</Label>
+          <Textarea
+            id="dataset-description"
+            value={description}
+            onChange={(event) => setDescription(event.target.value)}
+            placeholder="High-signal support traces for refund and escalation review."
+          />
+        </div>
+        {error ? <p className="text-sm text-rose-300">{error}</p> : null}
+        <Button
+          disabled={isPending || !name.trim()}
+          onClick={() => {
+            startTransition(async () => {
+              setError(null);
+
+              const response = await fetch(`/api/projects/${projectId}/datasets`, {
+                method: "POST",
+                headers: { "content-type": "application/json" },
+                body: JSON.stringify({
+                  name,
+                  description,
+                }),
+              });
+
+              if (!response.ok) {
+                const payload = (await response.json().catch(() => null)) as
+                  | { error?: string }
+                  | null;
+                setError(payload?.error ?? "Could not create dataset.");
+                return;
+              }
+
+              const payload = (await response.json()) as {
+                dataset: { id: string };
+              };
+              router.push(`/projects/${projectId}/datasets/${payload.dataset.id}`);
+              router.refresh();
+            });
+          }}
+        >
+          {isPending ? "Creating..." : "Create dataset"}
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/platform/components/dataset-import-form.tsx
+++ b/apps/platform/components/dataset-import-form.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+import type { DatasetFileFormat } from "@captar/types";
+
+import { Button } from "./ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "./ui/card";
+import { Label } from "./ui/label";
+
+const selectClassName =
+  "flex h-10 w-full rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300";
+
+export function DatasetImportForm({
+  projectId,
+  datasetId,
+}: {
+  projectId: string;
+  datasetId: string;
+}) {
+  const router = useRouter();
+  const [file, setFile] = useState<File | null>(null);
+  const [format, setFormat] = useState<DatasetFileFormat | "auto">("auto");
+  const [error, setError] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Import rows</CardTitle>
+        <CardDescription>
+          Append rows from a `json`, `jsonl`, or `csv` file into this dataset.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor="dataset-import-file">File</Label>
+          <input
+            id="dataset-import-file"
+            type="file"
+            accept=".json,.jsonl,.csv,application/json,text/csv,application/x-ndjson"
+            className="block w-full rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 file:mr-4 file:rounded-md file:border-0 file:bg-cyan-400/10 file:px-3 file:py-2 file:text-sm file:font-medium file:text-cyan-200"
+            onChange={(event) => setFile(event.target.files?.[0] ?? null)}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="dataset-import-format">Format</Label>
+          <select
+            id="dataset-import-format"
+            className={selectClassName}
+            value={format}
+            onChange={(event) =>
+              setFormat(event.target.value as DatasetFileFormat | "auto")
+            }
+          >
+            <option value="auto">Detect from file name</option>
+            <option value="json">JSON</option>
+            <option value="jsonl">JSONL</option>
+            <option value="csv">CSV</option>
+          </select>
+        </div>
+        {error ? <p className="text-sm text-rose-300">{error}</p> : null}
+        {message ? <p className="text-sm text-emerald-300">{message}</p> : null}
+        <Button
+          disabled={isPending || !file}
+          onClick={() => {
+            startTransition(async () => {
+              if (!file) {
+                return;
+              }
+
+              setError(null);
+              setMessage(null);
+
+              const body = new FormData();
+              body.set("file", file);
+              if (format !== "auto") {
+                body.set("format", format);
+              }
+
+              const response = await fetch(
+                `/api/projects/${projectId}/datasets/${datasetId}/import`,
+                {
+                  method: "POST",
+                  body,
+                },
+              );
+
+              if (!response.ok) {
+                const payload = (await response.json().catch(() => null)) as
+                  | { error?: string }
+                  | null;
+                setError(payload?.error ?? "Could not import dataset rows.");
+                return;
+              }
+
+              const payload = (await response.json()) as {
+                appendedCount: number;
+              };
+              setMessage(`Imported ${payload.appendedCount} row(s).`);
+              router.refresh();
+            });
+          }}
+        >
+          {isPending ? "Importing..." : "Import rows"}
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/platform/components/trace-dataset-export-card.tsx
+++ b/apps/platform/components/trace-dataset-export-card.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import Link from "next/link";
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+import { Button } from "./ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "./ui/card";
+import { Label } from "./ui/label";
+
+const selectClassName =
+  "flex h-10 w-full rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300";
+
+export function TraceDatasetExportCard({
+  projectId,
+  traceId,
+  datasets,
+  disabledReason,
+}: {
+  projectId: string;
+  traceId: string;
+  datasets: Array<{
+    id: string;
+    name: string;
+    rowCount: number;
+  }>;
+  disabledReason?: string;
+}) {
+  const router = useRouter();
+  const [datasetId, setDatasetId] = useState(datasets[0]?.id ?? "");
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const isDisabled = Boolean(disabledReason) || !datasets.length;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Export to dataset</CardTitle>
+        <CardDescription>
+          Turn this trace into an append-only dataset row for later review and eval prep.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {!datasets.length ? (
+          <div className="rounded-xl border border-slate-800 bg-slate-900/60 p-4 text-sm text-slate-300">
+            <p>No datasets exist in this project yet.</p>
+            <Link
+              className="mt-3 inline-flex text-cyan-300 hover:text-cyan-200"
+              href={`/projects/${projectId}/datasets`}
+            >
+              Create your first dataset
+            </Link>
+          </div>
+        ) : null}
+
+        {disabledReason ? (
+          <div className="rounded-xl border border-amber-500/30 bg-amber-500/10 p-4 text-sm text-amber-100">
+            {disabledReason}
+          </div>
+        ) : null}
+
+        {datasets.length ? (
+          <div className="space-y-2">
+            <Label htmlFor="trace-dataset-target">Dataset</Label>
+            <select
+              id="trace-dataset-target"
+              className={selectClassName}
+              value={datasetId}
+              onChange={(event) => setDatasetId(event.target.value)}
+            >
+              {datasets.map((dataset) => (
+                <option key={dataset.id} value={dataset.id}>
+                  {dataset.name} ({dataset.rowCount} rows)
+                </option>
+              ))}
+            </select>
+          </div>
+        ) : null}
+
+        {error ? <p className="text-sm text-rose-300">{error}</p> : null}
+
+        <Button
+          disabled={isPending || isDisabled || !datasetId}
+          onClick={() => {
+            startTransition(async () => {
+              setError(null);
+
+              const response = await fetch(
+                `/api/projects/${projectId}/datasets/${datasetId}/trace-export`,
+                {
+                  method: "POST",
+                  headers: { "content-type": "application/json" },
+                  body: JSON.stringify({ traceId }),
+                },
+              );
+
+              if (!response.ok) {
+                const payload = (await response.json().catch(() => null)) as
+                  | { error?: string }
+                  | null;
+                setError(payload?.error ?? "Could not export trace to dataset.");
+                return;
+              }
+
+              router.push(`/projects/${projectId}/datasets/${datasetId}`);
+              router.refresh();
+            });
+          }}
+        >
+          {isPending ? "Exporting..." : "Export trace"}
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/platform/lib/datasets.ts
+++ b/apps/platform/lib/datasets.ts
@@ -47,6 +47,24 @@ export function normalizeDatasetRowsFromText(
   }
 }
 
+export function inferDatasetFileFormat(fileName: string): DatasetFileFormat | null {
+  const normalized = fileName.trim().toLowerCase();
+
+  if (normalized.endsWith(".jsonl")) {
+    return "jsonl";
+  }
+
+  if (normalized.endsWith(".json")) {
+    return "json";
+  }
+
+  if (normalized.endsWith(".csv")) {
+    return "csv";
+  }
+
+  return null;
+}
+
 export function serializeDatasetRowsToText(
   rows: DatasetRowRecord[],
   format: DatasetFileFormat,

--- a/apps/platform/lib/platform.ts
+++ b/apps/platform/lib/platform.ts
@@ -586,10 +586,22 @@ export async function getProjectById(projectId: string, userId: string) {
         },
         orderBy: { updatedAt: "desc" },
       },
+      datasets: {
+        select: {
+          id: true,
+          name: true,
+          description: true,
+          rowCount: true,
+          updatedAt: true,
+        },
+        orderBy: { updatedAt: "desc" },
+        take: 5,
+      },
       _count: {
         select: {
           hooks: true,
           sessions: true,
+          datasets: true,
         },
       },
     },

--- a/apps/platform/test/datasets.test.ts
+++ b/apps/platform/test/datasets.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   buildTraceDatasetRow,
+  inferDatasetFileFormat,
   normalizeDatasetRowsFromText,
   serializeDatasetRowsToText,
 } from "../lib/datasets";
@@ -171,5 +172,12 @@ describe("dataset helpers", () => {
     expect(csv).toContain("\"{\"\"prompt\"\":\"\"What changed?\"\"}\"");
     expect(csv).toContain("trace_export");
     expect(csv).toContain("trace_db_3");
+  });
+
+  it("infers dataset file formats from file names", () => {
+    expect(inferDatasetFileFormat("captar-export.json")).toBe("json");
+    expect(inferDatasetFileFormat("captar-export.jsonl")).toBe("jsonl");
+    expect(inferDatasetFileFormat("captar-export.csv")).toBe("csv");
+    expect(inferDatasetFileFormat("captar-export.txt")).toBeNull();
   });
 });


### PR DESCRIPTION
## Linked Issue

- Closes #12

## Summary

- add project-scoped dataset pages, create and import forms, and dataset export endpoints under the existing project area
- add project detail links and counts for datasets plus trace-side export controls that turn retained payloads into dataset rows
- add dataset API routes for create, import, export, and trace-to-dataset actions on top of the new dataset core helpers
- extend dataset helper coverage for file-format detection used by the import workflow

## Validation

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] Additional validation noted below

Additional validation:
- [x] `pnpm --filter @captar/platform test`

## Risk and Rollback

- Risk level: medium, because this adds new authenticated routes and UI paths that depend on the stacked dataset core branch
- Rollback plan: revert this branch or close the stacked PR before merging into `main`, leaving the core persistence layer intact until a corrected platform workflow is ready

## Screenshots

- [ ] UI change with screenshots attached
- [x] No UI change
