### PR TITLE
chore: document dataset flow and harden coverage

### DIFF
--- a/.ai/current-focus.md
+++ b/.ai/current-focus.md
@@ -2,25 +2,24 @@
 
 - Last updated: 2026-04-08
 - Umbrella issue: `#3` - V1 traces-first foundation, repo memory, and GitHub workflow
-- Active delivery issues: `#4`, `#5`, and `#6`
+- Active delivery issues: `#11`, `#12`, and `#13`
 - Delivery model: split issue-linked branches and pull requests instead of one large branch
 
 ## V1 priorities now
 
-- Make traces span-first across the SDK and platform.
+- Turn traces into project-scoped datasets through the platform.
 - Keep the public SDK surface centered on `createCaptar()`, `wrapOpenAI()`, and `trackTool()`.
-- Upgrade the platform trace view from a flat event log into a debugging surface with tree and timeline structure.
-- Add shared repo memory and GitHub workflow enforcement so future work follows the same delivery process.
+- Keep eval execution out of scope until the dataset flow is stable.
+- Keep shared repo memory and GitHub workflow enforcement current as each split issue lands.
 
 ## Current split
 
-- `#4` repo workflow, `.ai` memory, templates, and GitHub admin scripts
-- `#5` SDK span tracing foundation
-- `#6` platform span persistence and debugger UI
+- `#11` dataset persistence, shared contracts, and backend helpers
+- `#12` platform dataset routes, pages, and trace export workflows
+- `#13` repo memory, docs, and dataset coverage
 
 ## Explicitly not shipping in v1
 
-- Datasets
 - Evals
 - Signals
 - SQL exploration

--- a/.ai/github-backlog.md
+++ b/.ai/github-backlog.md
@@ -3,10 +3,12 @@
 ## Active
 
 - `#3` V1 traces-first foundation, repo memory, and GitHub workflow
+- `#11` Add dataset core persistence and shared dataset contracts
+- `#12` Add platform dataset import/export and trace export workflows
+- `#13` Document dataset flow and add dataset coverage
 
 ## Next candidate issues
 
-- Add dataset export from traces after span-first tracing is stable
-- Design offline/manual evaluation runs on top of trace payloads
+- Design offline/manual evaluation runs on top of dataset rows
 - Define online evaluator model after dataset shape is settled
-
+- Add signals over trace and dataset activity after eval workflows exist

--- a/.ai/session-handoff.md
+++ b/.ai/session-handoff.md
@@ -20,10 +20,11 @@
 - Dataset milestone issues are created
 - PR `#14` publishes dataset persistence, shared contracts, backend helpers, and dataset normalization tests
 - PR `#15` publishes project dataset pages, import/export routes, and trace export workflows on top of `#14`
-- The current branch is reserved for repo memory, README/docs copy, and the last dataset coverage updates
+- PR `#16` publishes repo memory, README/docs copy, demo guidance, and the last dataset coverage updates
+- The full workspace validation currently passes with the stacked dataset branches open
 
 ## Next steps
 
-- Publish `#13` as the docs and coverage pull request on top of `#15`
-- Merge `#14`, then retarget the stacked dataset workflow PRs to `main`
+- Merge `#14`, then retarget `#15` to `main`
+- Merge `#15`, then retarget `#16` to `main`
 - Plan the follow-up issue for offline/manual evals over dataset rows

--- a/.ai/session-handoff.md
+++ b/.ai/session-handoff.md
@@ -17,10 +17,13 @@
 - GitHub issue templates, PR template, label sync, and branch protection scripts are added
 - Workspace validation passed with `pnpm lint` and `pnpm test`
 - GitHub labels were synchronized and `main` branch protection was applied
-- Dataset milestone issues are created and the first branch is reserved for schema, shared types, and backend helpers
+- Dataset milestone issues are created
+- PR `#14` publishes dataset persistence, shared contracts, backend helpers, and dataset normalization tests
+- PR `#15` publishes project dataset pages, import/export routes, and trace export workflows on top of `#14`
+- The current branch is reserved for repo memory, README/docs copy, and the last dataset coverage updates
 
 ## Next steps
 
-- Publish `#11` as the dataset core pull request
-- Stack `#12` for platform dataset workflows on top of `#11`
-- Stack `#13` for repo memory, docs, and extra dataset coverage on top of `#12`
+- Publish `#13` as the docs and coverage pull request on top of `#15`
+- Merge `#14`, then retarget the stacked dataset workflow PRs to `main`
+- Plan the follow-up issue for offline/manual evals over dataset rows

--- a/.ai/v1-roadmap.md
+++ b/.ai/v1-roadmap.md
@@ -5,22 +5,28 @@
 - TypeScript SDK for runtime control and tracing
 - OpenAI and OpenAI-compatible request wrapping
 - Span-first trace persistence
+- Project-scoped datasets built from traces and file imports
 - Spend, policy, payload retention, and violation tracking
-- Platform views for project, hook, and trace inspection
+- Platform views for project, hook, trace, and dataset inspection
 - Repo workflow rules, issue templates, PR template, and label sync
 
-## Near-term next after span foundation
+## Current milestone
 
-1. Dataset export from traces
-2. Offline and manual evaluation runs
-3. Online evaluators for production traffic
-4. Signals over trace/span data
-5. Search, SQL, dashboards, alerts, queues, debugger, and playground
+- Dataset export from traces
+- Dataset import and export in `json`, `jsonl`, and `csv`
+- Project-scoped dataset browsing in the platform
+
+## Near-term next after datasets
+
+1. Offline and manual evaluation runs
+2. Online evaluators for production traffic
+3. Signals over trace/span and dataset activity
+4. Search, SQL, dashboards, alerts, queues, debugger, and playground
 
 ## Ship criteria
 
 - SDK emits stable parent/child spans for session, request, and tool execution
 - Platform persists and renders spans
 - Trace pages show debugging-oriented structure instead of only event logs
+- Platform can export traces into append-only datasets and import rows from files
 - GitHub workflow is documented and automated enough to avoid direct-to-main work
-

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Captar is designed to provide:
 - Local-first policy enforcement for AI calls and tool execution
 - Budget reservation and reconciliation before and after model usage
 - Optional export of traces, spend events, and violations to a platform layer
+- Project-scoped datasets built from retained trace payloads
 - Minimal integration changes for teams already using OpenAI-based workflows
 
 ## Repository Overview
@@ -54,6 +55,7 @@ At a high level, the TypeScript runtime follows this sequence:
 5. Execute the provider or tool call
 6. Reconcile actual usage and release unused reserve
 7. Emit traces, spend records, and policy events
+8. Export strong traces into project datasets for later review or eval prep
 
 ## Getting Started
 
@@ -132,5 +134,16 @@ The current repository is focused on the first operational slice of Captar:
 - Spend-aware execution and reconciliation
 - Tool tracking and approval hooks
 - Optional export and platform ingestion paths
+- Platform trace debugging plus project-scoped dataset import/export workflows
 - Documentation, demo flows, and platform groundwork
 
+## Current Platform Workflow
+
+The current v1 platform flow is:
+
+1. Capture retained prompts and responses from traces.
+2. Inspect them in the platform trace debugger.
+3. Export useful traces into append-only project datasets.
+4. Import or export datasets as `json`, `jsonl`, or `csv`.
+
+Offline/manual eval execution is the next milestone after the dataset flow. It is not shipped in this repository yet.

--- a/apps/docs/app/page.tsx
+++ b/apps/docs/app/page.tsx
@@ -43,7 +43,8 @@ export default function DocsHomePage() {
           <p style={{ maxWidth: "42rem", fontSize: "1.1rem", lineHeight: 1.7 }}>
             Captar adds local hard budget enforcement, tool guardrails, and
             execution policies to OpenAI-based apps without forcing a gateway or
-            replacing provider SDKs.
+            replacing provider SDKs, then turns strong traces into reusable
+            project datasets for the next eval step.
           </p>
         </div>
         <article style={cardStyle}>

--- a/apps/docs/content/quickstart.mdx
+++ b/apps/docs/content/quickstart.mdx
@@ -1,6 +1,6 @@
 # Captar Quickstart
 
-Captor is a runtime control layer for AI calls. The SDK enforces spend, tool, and execution policy inside your app, then optionally exports traces and spend events to a hosted control plane.
+Captar is a runtime control layer for AI calls. The SDK enforces spend, tool, and execution policy inside your app, then optionally exports traces and spend events to a hosted control plane.
 
 ## Install
 
@@ -59,6 +59,15 @@ await captor.flush();
 3. Execute the model or tool call.
 4. Reconcile actual usage and release unused reserve.
 5. Emit events for traces, policy violations, and spend reporting.
+
+## Platform Workflow
+
+1. Inspect retained prompts and responses on the trace page.
+2. Export strong traces into a project dataset.
+3. Import or export datasets as `json`, `jsonl`, or `csv`.
+4. Prepare for offline/manual eval runs in the next milestone.
+
+Dataset export is part of the current v1 platform scope. Eval execution is not shipped yet.
 
 ## Event Types
 

--- a/apps/platform/test/datasets.test.ts
+++ b/apps/platform/test/datasets.test.ts
@@ -180,4 +180,41 @@ describe("dataset helpers", () => {
     expect(inferDatasetFileFormat("captar-export.csv")).toBe("csv");
     expect(inferDatasetFileFormat("captar-export.txt")).toBeNull();
   });
+
+  it("round-trips jsonl dataset exports through the shared row format", () => {
+    const rows = [
+      {
+        input: "Prompt A",
+        output: "Answer A",
+        source: {
+          kind: "trace_export" as const,
+          traceId: "trace_db_4",
+        },
+      },
+      {
+        input: { prompt: "Prompt B" },
+        metadata: { split: "eval" as const },
+      },
+    ];
+
+    const exported = serializeDatasetRowsToText(rows, "jsonl");
+    expect(normalizeDatasetRowsFromText(exported, "jsonl")).toEqual([
+      {
+        input: "Prompt A",
+        output: "Answer A",
+        source: {
+          kind: "trace_export",
+          traceId: "trace_db_4",
+        },
+      },
+      {
+        input: { prompt: "Prompt B" },
+        metadata: { split: "eval" },
+        source: {
+          kind: "file_import",
+          importedFormat: "jsonl",
+        },
+      },
+    ]);
+  });
 });

--- a/demo/live-openai-demo.mjs
+++ b/demo/live-openai-demo.mjs
@@ -158,6 +158,13 @@ try {
   console.log("\nSESSION SUMMARY");
   console.dir(summary, { depth: 6, colors: true });
 
+  if (controlPlaneBaseUrl) {
+    console.log("\nNEXT STEP");
+    console.log(
+      "Open the Captar platform trace view, then export the trace into a project dataset for later eval prep.",
+    );
+  }
+
   console.log("\nDONE");
 } catch (error) {
   console.error("\nLIVE REQUEST FAILED");


### PR DESCRIPTION
## Linked Issue

- Closes #13

## Summary

- update `.ai` repo memory so the dataset milestone, active split issues, and next eval-focused step are documented in-tree
- update README, docs copy, and demo guidance so the current platform flow is clearly traces to datasets, not eval execution
- add extra dataset coverage for file-format detection and jsonl round-tripping through the shared row format

## Validation

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] Additional validation noted below

Additional validation:
- [x] docs app builds during `pnpm test`
- [x] platform dataset helper tests pass with the new round-trip coverage

## Risk and Rollback

- Risk level: low, because this branch is limited to repo memory, docs/demo copy, and additional tests on top of the stacked dataset workflow branches
- Rollback plan: revert this branch without affecting the underlying dataset persistence or platform routes

## Screenshots

- [ ] UI change with screenshots attached
- [x] No UI change
