### PR TITLE
feat: add manual eval core

### DIFF
--- a/apps/platform/lib/manual-evals.ts
+++ b/apps/platform/lib/manual-evals.ts
@@ -1,0 +1,173 @@
+import type {
+  JsonValue,
+  ManualEvalCriterion,
+  ManualEvalCriterionAverage,
+  ManualEvalMetrics,
+  ManualEvalRunItemCriterionScore,
+  ManualEvalVerdict,
+} from "@captar/types";
+
+interface ManualEvalMetricItem {
+  verdict?: ManualEvalVerdict;
+  criterionScores?: ManualEvalRunItemCriterionScore[] | null;
+}
+
+function roundMetric(value: number) {
+  return Number(value.toFixed(3));
+}
+
+function scoreForCriterion(
+  scores: ManualEvalRunItemCriterionScore[] | null | undefined,
+  criterionId: string,
+) {
+  return scores?.find((entry) => entry.criterionId === criterionId)?.score;
+}
+
+export function buildEmptyManualEvalMetrics(
+  criteria: ManualEvalCriterion[],
+): ManualEvalMetrics {
+  return {
+    totalRows: 0,
+    reviewedRows: 0,
+    pendingRows: 0,
+    passCount: 0,
+    failCount: 0,
+    passRate: 0,
+    failRate: 0,
+    criterionAverages: criteria.map((criterion) => ({
+      criterionId: criterion.id,
+      label: criterion.label,
+      weight: criterion.weight,
+      reviewedRows: 0,
+    })),
+  };
+}
+
+export function calculateManualEvalOverallScore(
+  criteria: ManualEvalCriterion[],
+  scores: ManualEvalRunItemCriterionScore[],
+) {
+  if (!criteria.length || !scores.length) {
+    return undefined;
+  }
+
+  let weightedTotal = 0;
+  let totalWeight = 0;
+
+  for (const criterion of criteria) {
+    const score = scoreForCriterion(scores, criterion.id);
+    if (typeof score !== "number") {
+      continue;
+    }
+
+    weightedTotal += score * criterion.weight;
+    totalWeight += criterion.weight;
+  }
+
+  if (!totalWeight) {
+    return undefined;
+  }
+
+  return roundMetric(weightedTotal / totalWeight);
+}
+
+export function calculateManualEvalMetrics(
+  criteria: ManualEvalCriterion[],
+  items: ManualEvalMetricItem[],
+): ManualEvalMetrics {
+  const reviewedItems = items.filter((item) => item.verdict);
+  const passCount = reviewedItems.filter((item) => item.verdict === "pass").length;
+  const failCount = reviewedItems.filter((item) => item.verdict === "fail").length;
+  const overallScores = reviewedItems
+    .map((item) =>
+      calculateManualEvalOverallScore(criteria, item.criterionScores ?? []),
+    )
+    .filter((value): value is number => typeof value === "number");
+
+  const criterionAverages: ManualEvalCriterionAverage[] = criteria.map((criterion) => {
+    const criterionScores = reviewedItems
+      .map((item) => scoreForCriterion(item.criterionScores, criterion.id))
+      .filter((value): value is number => typeof value === "number");
+
+    return {
+      criterionId: criterion.id,
+      label: criterion.label,
+      weight: criterion.weight,
+      reviewedRows: criterionScores.length,
+      averageScore: criterionScores.length
+        ? roundMetric(
+            criterionScores.reduce((sum, score) => sum + score, 0) /
+              criterionScores.length,
+          )
+        : undefined,
+    };
+  });
+
+  const reviewedRows = reviewedItems.length;
+  const totalRows = items.length;
+  const pendingRows = Math.max(totalRows - reviewedRows, 0);
+
+  return {
+    totalRows,
+    reviewedRows,
+    pendingRows,
+    passCount,
+    failCount,
+    passRate: reviewedRows ? roundMetric(passCount / reviewedRows) : 0,
+    failRate: reviewedRows ? roundMetric(failCount / reviewedRows) : 0,
+    overallAverageScore: overallScores.length
+      ? roundMetric(
+          overallScores.reduce((sum, score) => sum + score, 0) / overallScores.length,
+        )
+      : undefined,
+    criterionAverages,
+  };
+}
+
+export function parseManualEvalCriterionAverages(
+  value: JsonValue | null | undefined,
+  criteria: ManualEvalCriterion[],
+) {
+  if (!Array.isArray(value)) {
+    return buildEmptyManualEvalMetrics(criteria).criterionAverages;
+  }
+
+  const entries = new Map(
+    value
+      .filter((entry): entry is Record<string, JsonValue | undefined> =>
+        Boolean(entry && typeof entry === "object" && !Array.isArray(entry)),
+      )
+      .map((entry) => [
+        typeof entry.criterionId === "string" ? entry.criterionId : "",
+        entry,
+      ]),
+  );
+
+  return criteria.map((criterion) => {
+    const stored = entries.get(criterion.id);
+    const averageScore =
+      typeof stored?.averageScore === "number" ? stored.averageScore : undefined;
+    const reviewedRows =
+      typeof stored?.reviewedRows === "number" ? stored.reviewedRows : 0;
+
+    return {
+      criterionId: criterion.id,
+      label: criterion.label,
+      weight: criterion.weight,
+      reviewedRows,
+      averageScore,
+    };
+  });
+}
+
+export function manualEvalCriterionAveragesToJson(
+  value: ManualEvalCriterionAverage[],
+): JsonValue {
+  return value.map((entry) => ({
+    criterionId: entry.criterionId,
+    label: entry.label,
+    weight: entry.weight,
+    reviewedRows: entry.reviewedRows,
+    averageScore: entry.averageScore ?? null,
+  }));
+}

--- a/apps/platform/lib/platform.ts
+++ b/apps/platform/lib/platform.ts
@@ -2,6 +2,8 @@ import {
   DatasetSourceKind,
   HookStatus,
   LedgerKind,
+  ManualEvalRunStatus,
+  ManualEvalVerdict,
   PayloadRetention,
   ProjectRole,
   TraceSpanKind,
@@ -17,6 +19,15 @@ import type {
   ExportBatch,
   JsonObject,
   JsonValue,
+  ManualEval,
+  ManualEvalCriterion,
+  ManualEvalCriterionAverage,
+  ManualEvalMetrics,
+  ManualEvalRun,
+  ManualEvalRunItem,
+  ManualEvalRunItemCriterionScore,
+  ManualEvalRunStatus as ManualEvalRunStatusValue,
+  ManualEvalVerdict as ManualEvalVerdictValue,
   PayloadRetentionMode,
   TraceDatasetExportInput,
   TraceSpanSnapshot,
@@ -28,6 +39,13 @@ import {
   serializeDatasetRowsToText,
 } from "./datasets";
 import { prisma } from "./db";
+import {
+  buildEmptyManualEvalMetrics,
+  calculateManualEvalMetrics,
+  calculateManualEvalOverallScore,
+  manualEvalCriterionAveragesToJson,
+  parseManualEvalCriterionAverages,
+} from "./manual-evals";
 import { extractPromptContent, extractResponseContent, redactContent } from "./redaction";
 import { summarizeTraceFromSpans } from "./trace-spans";
 import { slugify } from "./utils";
@@ -280,6 +298,282 @@ function toDatasetRowSnapshot(row: {
       outputRetentionMode: toPayloadRetentionMode(row.outputRetentionMode),
     },
     createdAt: row.createdAt.toISOString(),
+  };
+}
+
+function fromManualEvalRunStatus(
+  status: ManualEvalRunStatus,
+): ManualEvalRunStatusValue {
+  switch (status) {
+    case ManualEvalRunStatus.COMPLETED:
+      return "completed";
+    case ManualEvalRunStatus.IN_PROGRESS:
+    default:
+      return "in_progress";
+  }
+}
+
+function toManualEvalVerdict(
+  verdict: ManualEvalVerdictValue,
+): ManualEvalVerdict {
+  switch (verdict) {
+    case "fail":
+      return ManualEvalVerdict.FAIL;
+    case "pass":
+    default:
+      return ManualEvalVerdict.PASS;
+  }
+}
+
+function fromManualEvalVerdict(
+  verdict: ManualEvalVerdict | null | undefined,
+): ManualEvalVerdictValue | undefined {
+  switch (verdict) {
+    case ManualEvalVerdict.FAIL:
+      return "fail";
+    case ManualEvalVerdict.PASS:
+      return "pass";
+    default:
+      return undefined;
+  }
+}
+
+function parseManualEvalRunItemCriterionScores(
+  value: Prisma.JsonValue | null | undefined,
+): ManualEvalRunItemCriterionScore[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.flatMap((entry) => {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      return [];
+    }
+
+    return typeof entry.criterionId === "string" && typeof entry.score === "number"
+      ? [{ criterionId: entry.criterionId, score: entry.score }]
+      : [];
+  });
+}
+
+function toManualEvalCriterionSnapshot(criterion: {
+  id: string;
+  position: number;
+  label: string;
+  description: string | null;
+  weight: number;
+}): ManualEvalCriterion {
+  return {
+    id: criterion.id,
+    position: criterion.position,
+    label: criterion.label,
+    description: criterion.description ?? undefined,
+    weight: criterion.weight,
+  };
+}
+
+function toManualEvalMetricsSnapshot(
+  value: {
+    totalRows: number;
+    reviewedRows: number;
+    pendingRows: number;
+    passCount: number;
+    failCount: number;
+    averageScore: Prisma.Decimal | number | null | undefined;
+    criterionAverages: Prisma.JsonValue | null;
+  },
+  criteria: ManualEvalCriterion[],
+): ManualEvalMetrics {
+  const reviewedRows = value.reviewedRows;
+
+  return {
+    totalRows: value.totalRows,
+    reviewedRows,
+    pendingRows: value.pendingRows,
+    passCount: value.passCount,
+    failCount: value.failCount,
+    passRate: reviewedRows
+      ? Number((value.passCount / reviewedRows).toFixed(3))
+      : 0,
+    failRate: reviewedRows
+      ? Number((value.failCount / reviewedRows).toFixed(3))
+      : 0,
+    overallAverageScore: reviewedRows
+      ? decimalToNumber(value.averageScore)
+      : undefined,
+    criterionAverages: parseManualEvalCriterionAverages(
+      value.criterionAverages as JsonValue | null,
+      criteria,
+    ),
+  };
+}
+
+function toManualEvalSnapshot(evalRecord: {
+  id: string;
+  projectId: string;
+  datasetId: string;
+  name: string;
+  description: string | null;
+  reviewerInstructions: string | null;
+  runCount: number;
+  totalRows: number;
+  reviewedRows: number;
+  pendingRows: number;
+  passCount: number;
+  failCount: number;
+  averageScore: Prisma.Decimal | number | null | undefined;
+  criterionAverages: Prisma.JsonValue | null;
+  createdAt: Date;
+  updatedAt: Date;
+  criteria: Array<{
+    id: string;
+    position: number;
+    label: string;
+    description: string | null;
+    weight: number;
+  }>;
+}): ManualEval {
+  const criteria = evalRecord.criteria
+    .sort((left, right) => left.position - right.position)
+    .map(toManualEvalCriterionSnapshot);
+
+  return {
+    id: evalRecord.id,
+    projectId: evalRecord.projectId,
+    datasetId: evalRecord.datasetId,
+    name: evalRecord.name,
+    description: evalRecord.description ?? undefined,
+    reviewerInstructions: evalRecord.reviewerInstructions ?? undefined,
+    runCount: evalRecord.runCount,
+    metrics: toManualEvalMetricsSnapshot(evalRecord, criteria),
+    criteria,
+    createdAt: evalRecord.createdAt.toISOString(),
+    updatedAt: evalRecord.updatedAt.toISOString(),
+  };
+}
+
+function toManualEvalRunItemSnapshot(item: {
+  id: string;
+  position: number;
+  verdict: ManualEvalVerdict | null;
+  notes: string | null;
+  overallScore: Prisma.Decimal | number | null;
+  criterionScores: Prisma.JsonValue | null;
+  reviewerUserId: string | null;
+  reviewedAt: Date | null;
+  runId: string;
+  datasetRow: {
+    id: string;
+    datasetId: string;
+    position: number;
+    input: Prisma.JsonValue;
+    output: Prisma.JsonValue | null;
+    metadata: Prisma.JsonValue | null;
+    sourceKind: DatasetSourceKind;
+    sourceTraceId: string | null;
+    sourceExternalTraceId: string | null;
+    sourceSpanId: string | null;
+    inputRetentionMode: PayloadRetention | null;
+    outputRetentionMode: PayloadRetention | null;
+    createdAt: Date;
+  };
+}): ManualEvalRunItem {
+  return {
+    id: item.id,
+    runId: item.runId,
+    datasetRowId: item.datasetRow.id,
+    position: item.position,
+    row: toDatasetRowSnapshot(item.datasetRow),
+    verdict: fromManualEvalVerdict(item.verdict),
+    notes: item.notes ?? undefined,
+    overallScore:
+      item.overallScore == null ? undefined : decimalToNumber(item.overallScore),
+    criterionScores: parseManualEvalRunItemCriterionScores(item.criterionScores),
+    reviewerUserId: item.reviewerUserId ?? undefined,
+    reviewedAt: item.reviewedAt?.toISOString(),
+  };
+}
+
+function toManualEvalRunSnapshot(run: {
+  id: string;
+  manualEvalId: string;
+  datasetId: string;
+  status: ManualEvalRunStatus;
+  createdByUserId: string;
+  totalRows: number;
+  reviewedRows: number;
+  pendingRows: number;
+  passCount: number;
+  failCount: number;
+  averageScore: Prisma.Decimal | number | null | undefined;
+  criterionAverages: Prisma.JsonValue | null;
+  completedAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+  items?: Array<{
+    id: string;
+    position: number;
+    verdict: ManualEvalVerdict | null;
+    notes: string | null;
+    overallScore: Prisma.Decimal | number | null;
+    criterionScores: Prisma.JsonValue | null;
+    reviewerUserId: string | null;
+    reviewedAt: Date | null;
+    runId: string;
+    datasetRow: {
+      id: string;
+      datasetId: string;
+      position: number;
+      input: Prisma.JsonValue;
+      output: Prisma.JsonValue | null;
+      metadata: Prisma.JsonValue | null;
+      sourceKind: DatasetSourceKind;
+      sourceTraceId: string | null;
+      sourceExternalTraceId: string | null;
+      sourceSpanId: string | null;
+      inputRetentionMode: PayloadRetention | null;
+      outputRetentionMode: PayloadRetention | null;
+      createdAt: Date;
+    };
+  }>;
+  manualEval: {
+    criteria: Array<{
+      id: string;
+      position: number;
+      label: string;
+      description: string | null;
+      weight: number;
+    }>;
+  };
+}): ManualEvalRun {
+  const criteria = run.manualEval.criteria
+    .sort((left, right) => left.position - right.position)
+    .map(toManualEvalCriterionSnapshot);
+
+  return {
+    id: run.id,
+    manualEvalId: run.manualEvalId,
+    datasetId: run.datasetId,
+    status: fromManualEvalRunStatus(run.status),
+    createdByUserId: run.createdByUserId,
+    metrics: toManualEvalMetricsSnapshot(
+      {
+        totalRows: run.totalRows,
+        reviewedRows: run.reviewedRows,
+        pendingRows: run.pendingRows,
+        passCount: run.passCount,
+        failCount: run.failCount,
+        averageScore: run.averageScore,
+        criterionAverages: run.criterionAverages,
+      },
+      criteria,
+    ),
+    items: (run.items ?? [])
+      .sort((left, right) => left.position - right.position)
+      .map(toManualEvalRunItemSnapshot),
+    completedAt: run.completedAt?.toISOString(),
+    createdAt: run.createdAt.toISOString(),
+    updatedAt: run.updatedAt.toISOString(),
   };
 }
 
@@ -943,6 +1237,568 @@ export async function appendTraceToDataset(
     dataset,
     row: toDatasetRowSnapshot(insertedRow),
   };
+}
+
+async function recomputeManualEvalRunMetrics(
+  transaction: Prisma.TransactionClient,
+  runId: string,
+) {
+  const run = await transaction.manualEvalRun.findUnique({
+    where: { id: runId },
+    include: {
+      manualEval: {
+        include: {
+          criteria: {
+            orderBy: { position: "asc" },
+          },
+        },
+      },
+      items: {
+        select: {
+          verdict: true,
+          criterionScores: true,
+        },
+      },
+    },
+  });
+
+  if (!run) {
+    return null;
+  }
+
+  const criteria = run.manualEval.criteria.map(toManualEvalCriterionSnapshot);
+  const metrics = calculateManualEvalMetrics(
+    criteria,
+    run.items.map((item) => ({
+      verdict: fromManualEvalVerdict(item.verdict),
+      criterionScores: parseManualEvalRunItemCriterionScores(item.criterionScores),
+    })),
+  );
+  const status =
+    metrics.pendingRows === 0
+      ? ManualEvalRunStatus.COMPLETED
+      : ManualEvalRunStatus.IN_PROGRESS;
+
+  await transaction.manualEvalRun.update({
+    where: { id: run.id },
+    data: {
+      totalRows: metrics.totalRows,
+      reviewedRows: metrics.reviewedRows,
+      pendingRows: metrics.pendingRows,
+      passCount: metrics.passCount,
+      failCount: metrics.failCount,
+      averageScore: metrics.overallAverageScore ?? 0,
+      criterionAverages: nestedJsonValueToPrisma(
+        manualEvalCriterionAveragesToJson(metrics.criterionAverages),
+      ) as Prisma.InputJsonValue,
+      status,
+      completedAt:
+        status === ManualEvalRunStatus.COMPLETED ? run.completedAt ?? new Date() : null,
+    },
+  });
+
+  return {
+    runId: run.id,
+    manualEvalId: run.manualEvalId,
+    status,
+    metrics,
+  };
+}
+
+async function recomputeManualEvalMetrics(
+  transaction: Prisma.TransactionClient,
+  manualEvalId: string,
+) {
+  const manualEval = await transaction.manualEval.findUnique({
+    where: { id: manualEvalId },
+    include: {
+      criteria: {
+        orderBy: { position: "asc" },
+      },
+      runs: {
+        include: {
+          items: {
+            select: {
+              verdict: true,
+              criterionScores: true,
+            },
+          },
+        },
+      },
+    },
+  });
+
+  if (!manualEval) {
+    return null;
+  }
+
+  const criteria = manualEval.criteria.map(toManualEvalCriterionSnapshot);
+  const metrics = calculateManualEvalMetrics(
+    criteria,
+    manualEval.runs.flatMap((run) =>
+      run.items.map((item) => ({
+        verdict: fromManualEvalVerdict(item.verdict),
+        criterionScores: parseManualEvalRunItemCriterionScores(item.criterionScores),
+      })),
+    ),
+  );
+
+  await transaction.manualEval.update({
+    where: { id: manualEval.id },
+    data: {
+      runCount: manualEval.runs.length,
+      totalRows: metrics.totalRows,
+      reviewedRows: metrics.reviewedRows,
+      pendingRows: metrics.pendingRows,
+      passCount: metrics.passCount,
+      failCount: metrics.failCount,
+      averageScore: metrics.overallAverageScore ?? 0,
+      criterionAverages: nestedJsonValueToPrisma(
+        manualEvalCriterionAveragesToJson(metrics.criterionAverages),
+      ) as Prisma.InputJsonValue,
+    },
+  });
+
+  return {
+    manualEvalId: manualEval.id,
+    metrics,
+  };
+}
+
+function normalizeManualEvalCriterionScores(
+  criteria: ManualEvalCriterion[],
+  scores: ManualEvalRunItemCriterionScore[],
+) {
+  const entries = new Map(scores.map((entry) => [entry.criterionId, entry.score]));
+
+  if (entries.size !== criteria.length) {
+    throw new Error("Every rubric criterion must receive exactly one score.");
+  }
+
+  return criteria.map((criterion) => {
+    const score = entries.get(criterion.id);
+
+    if (
+      typeof score !== "number" ||
+      !Number.isInteger(score) ||
+      score < 1 ||
+      score > 5
+    ) {
+      throw new Error("Criterion scores must be integers between 1 and 5.");
+    }
+
+    return {
+      criterionId: criterion.id,
+      score,
+    };
+  });
+}
+
+export async function listProjectManualEvals(projectId: string, userId: string) {
+  const manualEvals = await prisma.manualEval.findMany({
+    where: {
+      projectId,
+      project: {
+        members: {
+          some: { userId },
+        },
+      },
+    },
+    include: {
+      criteria: {
+        orderBy: { position: "asc" },
+      },
+      dataset: true,
+      runs: {
+        orderBy: { createdAt: "desc" },
+        take: 1,
+      },
+    },
+    orderBy: { updatedAt: "desc" },
+  });
+
+  return manualEvals.map((manualEval) => {
+    const snapshot = toManualEvalSnapshot(manualEval);
+
+    return {
+      ...snapshot,
+      dataset: toDatasetSnapshot(manualEval.dataset),
+      latestRun: manualEval.runs[0]
+        ? toManualEvalRunSnapshot({
+            ...manualEval.runs[0],
+            items: [],
+            manualEval: {
+              criteria: manualEval.criteria,
+            },
+          })
+        : null,
+    };
+  });
+}
+
+export async function createProjectManualEval(
+  projectId: string,
+  userId: string,
+  input: {
+    datasetId: string;
+    name: string;
+    description?: string | null;
+    reviewerInstructions?: string | null;
+    criteria: Array<{
+      label: string;
+      description?: string | null;
+      weight?: number;
+    }>;
+  },
+) {
+  return prisma.$transaction(async (transaction) => {
+    const dataset = await transaction.dataset.findFirst({
+      where: {
+        id: input.datasetId,
+        projectId,
+        project: {
+          members: {
+            some: { userId },
+          },
+        },
+      },
+    });
+
+    if (!dataset) {
+      return null;
+    }
+
+    const manualEval = await transaction.manualEval.create({
+      data: {
+        projectId,
+        datasetId: dataset.id,
+        name: input.name.trim(),
+        description: input.description?.trim() || null,
+        reviewerInstructions: input.reviewerInstructions?.trim() || null,
+        averageScore: 0,
+        criterionAverages: [] as Prisma.InputJsonArray,
+        criteria: {
+          create: input.criteria.map((criterion, index) => ({
+            position: index + 1,
+            label: criterion.label.trim(),
+            description: criterion.description?.trim() || null,
+            weight: Math.max(1, Math.trunc(criterion.weight ?? 1)),
+          })),
+        },
+      },
+      include: {
+        criteria: {
+          orderBy: { position: "asc" },
+        },
+      },
+    });
+
+    return toManualEvalSnapshot(manualEval);
+  });
+}
+
+export async function getProjectManualEvalById(
+  projectId: string,
+  manualEvalId: string,
+  userId: string,
+) {
+  const manualEval = await prisma.manualEval.findFirst({
+    where: {
+      id: manualEvalId,
+      projectId,
+      project: {
+        members: {
+          some: { userId },
+        },
+      },
+    },
+    include: {
+      criteria: {
+        orderBy: { position: "asc" },
+      },
+      dataset: {
+        include: {
+          rows: {
+            orderBy: { position: "asc" },
+          },
+        },
+      },
+      runs: {
+        orderBy: { createdAt: "desc" },
+        include: {
+          manualEval: {
+            include: {
+              criteria: {
+                orderBy: { position: "asc" },
+              },
+            },
+          },
+        },
+      },
+    },
+  });
+
+  if (!manualEval) {
+    return null;
+  }
+
+  return {
+    manualEval: toManualEvalSnapshot(manualEval),
+    dataset: {
+      ...toDatasetSnapshot(manualEval.dataset),
+      rows: manualEval.dataset.rows.map(toDatasetRowSnapshot),
+    },
+    runs: manualEval.runs.map((run) =>
+      toManualEvalRunSnapshot({
+        ...run,
+        items: [],
+      }),
+    ),
+  };
+}
+
+export async function createProjectManualEvalRun(
+  projectId: string,
+  manualEvalId: string,
+  userId: string,
+) {
+  return prisma.$transaction(async (transaction) => {
+    const manualEval = await transaction.manualEval.findFirst({
+      where: {
+        id: manualEvalId,
+        projectId,
+        project: {
+          members: {
+            some: { userId },
+          },
+        },
+      },
+      include: {
+        criteria: {
+          orderBy: { position: "asc" },
+        },
+        dataset: {
+          include: {
+            rows: {
+              orderBy: { position: "asc" },
+            },
+          },
+        },
+      },
+    });
+
+    if (!manualEval) {
+      return null;
+    }
+
+    if (!manualEval.dataset.rows.length) {
+      throw new Error("Manual eval runs require at least one dataset row.");
+    }
+
+    const emptyMetrics = buildEmptyManualEvalMetrics(
+      manualEval.criteria.map(toManualEvalCriterionSnapshot),
+    );
+    const run = await transaction.manualEvalRun.create({
+      data: {
+        manualEvalId: manualEval.id,
+        datasetId: manualEval.datasetId,
+        createdByUserId: userId,
+        totalRows: manualEval.dataset.rows.length,
+        pendingRows: manualEval.dataset.rows.length,
+        averageScore: 0,
+        criterionAverages: nestedJsonValueToPrisma(
+          manualEvalCriterionAveragesToJson(emptyMetrics.criterionAverages),
+        ) as Prisma.InputJsonValue,
+      },
+    });
+
+    await transaction.manualEvalRunItem.createMany({
+      data: manualEval.dataset.rows.map((row) => ({
+        runId: run.id,
+        datasetRowId: row.id,
+        position: row.position,
+      })),
+    });
+
+    await recomputeManualEvalRunMetrics(transaction, run.id);
+    await recomputeManualEvalMetrics(transaction, manualEval.id);
+
+    const createdRun = await transaction.manualEvalRun.findUnique({
+      where: { id: run.id },
+      include: {
+        items: {
+          include: {
+            datasetRow: true,
+          },
+          orderBy: { position: "asc" },
+        },
+        manualEval: {
+          include: {
+            criteria: {
+              orderBy: { position: "asc" },
+            },
+          },
+        },
+      },
+    });
+
+    return createdRun ? toManualEvalRunSnapshot(createdRun) : null;
+  });
+}
+
+export async function getProjectManualEvalRunById(
+  projectId: string,
+  manualEvalId: string,
+  runId: string,
+  userId: string,
+) {
+  const run = await prisma.manualEvalRun.findFirst({
+    where: {
+      id: runId,
+      manualEvalId,
+      manualEval: {
+        projectId,
+        project: {
+          members: {
+            some: { userId },
+          },
+        },
+      },
+    },
+    include: {
+      items: {
+        include: {
+          datasetRow: true,
+        },
+        orderBy: { position: "asc" },
+      },
+      manualEval: {
+        include: {
+          criteria: {
+            orderBy: { position: "asc" },
+          },
+          dataset: true,
+        },
+      },
+    },
+  });
+
+  if (!run) {
+    return null;
+  }
+
+  return {
+    manualEval: toManualEvalSnapshot(run.manualEval),
+    dataset: toDatasetSnapshot(run.manualEval.dataset),
+    run: toManualEvalRunSnapshot(run),
+  };
+}
+
+export async function saveManualEvalRunItemReview(
+  projectId: string,
+  manualEvalId: string,
+  runId: string,
+  itemId: string,
+  userId: string,
+  input: {
+    verdict: ManualEvalVerdictValue;
+    notes?: string | null;
+    criterionScores: ManualEvalRunItemCriterionScore[];
+  },
+) {
+  return prisma.$transaction(async (transaction) => {
+    const item = await transaction.manualEvalRunItem.findFirst({
+      where: {
+        id: itemId,
+        runId,
+        run: {
+          manualEvalId,
+          manualEval: {
+            projectId,
+            project: {
+              members: {
+                some: { userId },
+              },
+            },
+          },
+        },
+      },
+      include: {
+        run: {
+          include: {
+            manualEval: {
+              include: {
+                criteria: {
+                  orderBy: { position: "asc" },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    if (!item) {
+      return null;
+    }
+
+    const criteria = item.run.manualEval.criteria.map(toManualEvalCriterionSnapshot);
+    const normalizedScores = normalizeManualEvalCriterionScores(
+      criteria,
+      input.criterionScores,
+    );
+    const overallScore = calculateManualEvalOverallScore(criteria, normalizedScores);
+
+    await transaction.manualEvalRunItem.update({
+      where: { id: item.id },
+      data: {
+        verdict: toManualEvalVerdict(input.verdict),
+        notes: input.notes?.trim() || null,
+        overallScore: overallScore ?? 0,
+        criterionScores: nestedJsonValueToPrisma(
+          normalizedScores.map((entry) => ({
+            criterionId: entry.criterionId,
+            score: entry.score,
+          })),
+        ) as Prisma.InputJsonValue,
+        reviewerUserId: userId,
+        reviewedAt: new Date(),
+      },
+    });
+
+    await recomputeManualEvalRunMetrics(transaction, runId);
+    await recomputeManualEvalMetrics(transaction, manualEvalId);
+
+    const updatedRun = await transaction.manualEvalRun.findUnique({
+      where: { id: runId },
+      include: {
+        items: {
+          include: {
+            datasetRow: true,
+          },
+          orderBy: { position: "asc" },
+        },
+        manualEval: {
+          include: {
+            criteria: {
+              orderBy: { position: "asc" },
+            },
+            dataset: true,
+          },
+        },
+      },
+    });
+
+    if (!updatedRun) {
+      return null;
+    }
+
+    return {
+      manualEval: toManualEvalSnapshot(updatedRun.manualEval),
+      dataset: toDatasetSnapshot(updatedRun.manualEval.dataset),
+      run: toManualEvalRunSnapshot(updatedRun),
+    };
+  });
 }
 
 function findOrCreateTraceState(

--- a/apps/platform/test/manual-evals.test.ts
+++ b/apps/platform/test/manual-evals.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildEmptyManualEvalMetrics,
+  calculateManualEvalMetrics,
+  calculateManualEvalOverallScore,
+  manualEvalCriterionAveragesToJson,
+  parseManualEvalCriterionAverages,
+} from "../lib/manual-evals";
+
+const criteria = [
+  {
+    id: "accuracy",
+    position: 1,
+    label: "Accuracy",
+    weight: 2,
+  },
+  {
+    id: "grounding",
+    position: 2,
+    label: "Grounding",
+    weight: 1,
+  },
+] as const;
+
+describe("manual eval helpers", () => {
+  it("calculates weighted overall scores", () => {
+    expect(
+      calculateManualEvalOverallScore(
+        [...criteria],
+        [
+          { criterionId: "accuracy", score: 4 },
+          { criterionId: "grounding", score: 5 },
+        ],
+      ),
+    ).toBe(4.333);
+  });
+
+  it("calculates review metrics and criterion averages", () => {
+    const metrics = calculateManualEvalMetrics([...criteria], [
+      {
+        verdict: "pass",
+        criterionScores: [
+          { criterionId: "accuracy", score: 5 },
+          { criterionId: "grounding", score: 4 },
+        ],
+      },
+      {
+        verdict: "fail",
+        criterionScores: [
+          { criterionId: "accuracy", score: 2 },
+          { criterionId: "grounding", score: 3 },
+        ],
+      },
+      {},
+    ]);
+
+    expect(metrics).toEqual({
+      totalRows: 3,
+      reviewedRows: 2,
+      pendingRows: 1,
+      passCount: 1,
+      failCount: 1,
+      passRate: 0.5,
+      failRate: 0.5,
+      overallAverageScore: 3.5,
+      criterionAverages: [
+        {
+          criterionId: "accuracy",
+          label: "Accuracy",
+          weight: 2,
+          reviewedRows: 2,
+          averageScore: 3.5,
+        },
+        {
+          criterionId: "grounding",
+          label: "Grounding",
+          weight: 1,
+          reviewedRows: 2,
+          averageScore: 3.5,
+        },
+      ],
+    });
+  });
+
+  it("builds empty metrics when no reviews exist", () => {
+    expect(buildEmptyManualEvalMetrics([...criteria])).toEqual({
+      totalRows: 0,
+      reviewedRows: 0,
+      pendingRows: 0,
+      passCount: 0,
+      failCount: 0,
+      passRate: 0,
+      failRate: 0,
+      criterionAverages: [
+        {
+          criterionId: "accuracy",
+          label: "Accuracy",
+          weight: 2,
+          reviewedRows: 0,
+        },
+        {
+          criterionId: "grounding",
+          label: "Grounding",
+          weight: 1,
+          reviewedRows: 0,
+        },
+      ],
+    });
+  });
+
+  it("round-trips stored criterion averages onto the rubric", () => {
+    const json = manualEvalCriterionAveragesToJson([
+      {
+        criterionId: "grounding",
+        label: "Grounding",
+        weight: 1,
+        reviewedRows: 3,
+        averageScore: 4,
+      },
+      {
+        criterionId: "accuracy",
+        label: "Accuracy",
+        weight: 2,
+        reviewedRows: 3,
+        averageScore: 3.667,
+      },
+    ]);
+
+    expect(parseManualEvalCriterionAverages(json, [...criteria])).toEqual([
+      {
+        criterionId: "accuracy",
+        label: "Accuracy",
+        weight: 2,
+        reviewedRows: 3,
+        averageScore: 3.667,
+      },
+      {
+        criterionId: "grounding",
+        label: "Grounding",
+        weight: 1,
+        reviewedRows: 3,
+        averageScore: 4,
+      },
+    ]);
+  });
+});

--- a/db/prisma/schema.prisma
+++ b/db/prisma/schema.prisma
@@ -56,19 +56,31 @@ enum DatasetSourceKind {
   FILE_IMPORT
 }
 
+enum ManualEvalRunStatus {
+  IN_PROGRESS
+  COMPLETED
+}
+
+enum ManualEvalVerdict {
+  PASS
+  FAIL
+}
+
 model User {
-  id            String          @id @default(cuid())
-  name          String?
-  email         String?         @unique
-  emailVerified DateTime?
-  image         String?
-  passwordHash  String?
-  createdAt     DateTime        @default(now())
-  updatedAt     DateTime        @updatedAt
-  accounts      Account[]
-  sessions      Session[]
-  memberships   ProjectMember[]
-  projectsOwned Project[]       @relation("ProjectOwner")
+  id                   String              @id @default(cuid())
+  name                 String?
+  email                String?             @unique
+  emailVerified        DateTime?
+  image                String?
+  passwordHash         String?
+  createdAt            DateTime            @default(now())
+  updatedAt            DateTime            @updatedAt
+  accounts             Account[]
+  sessions             Session[]
+  memberships          ProjectMember[]
+  projectsOwned        Project[]           @relation("ProjectOwner")
+  manualEvalRunsCreated ManualEvalRun[]    @relation("ManualEvalRunCreator")
+  manualEvalReviews    ManualEvalRunItem[] @relation("ManualEvalReviewer")
 }
 
 model Account {
@@ -106,18 +118,19 @@ model VerificationToken {
 }
 
 model Project {
-  id          String          @id @default(cuid())
-  slug        String          @unique
+  id          String       @id @default(cuid())
+  slug        String       @unique
   name        String
   description String?
   ownerId     String
-  createdAt   DateTime        @default(now())
-  updatedAt   DateTime        @updatedAt
-  owner       User            @relation("ProjectOwner", fields: [ownerId], references: [id], onDelete: Cascade)
+  createdAt   DateTime     @default(now())
+  updatedAt   DateTime     @updatedAt
+  owner       User         @relation("ProjectOwner", fields: [ownerId], references: [id], onDelete: Cascade)
   members     ProjectMember[]
   hooks       HookConnection[]
   sessions    LLMSession[]
   datasets    Dataset[]
+  manualEvals ManualEval[]
 }
 
 model ProjectMember {
@@ -273,40 +286,132 @@ model TraceSpan {
 }
 
 model Dataset {
-  id          String       @id @default(cuid())
-  name        String
-  description String?
-  rowCount    Int          @default(0)
-  createdAt   DateTime     @default(now())
-  updatedAt   DateTime     @updatedAt
-  projectId   String
-  project     Project      @relation(fields: [projectId], references: [id], onDelete: Cascade)
-  rows        DatasetRow[]
+  id             String          @id @default(cuid())
+  name           String
+  description    String?
+  rowCount       Int             @default(0)
+  createdAt      DateTime        @default(now())
+  updatedAt      DateTime        @updatedAt
+  projectId      String
+  project        Project         @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  rows           DatasetRow[]
+  manualEvals    ManualEval[]
+  manualEvalRuns ManualEvalRun[]
 
   @@unique([projectId, name])
   @@index([projectId, createdAt])
 }
 
 model DatasetRow {
-  id                  String            @id @default(cuid())
-  position            Int
-  input               Json
-  output              Json?
-  metadata            Json?
-  sourceKind          DatasetSourceKind
-  sourceTraceId       String?
+  id                   String             @id @default(cuid())
+  position             Int
+  input                Json
+  output               Json?
+  metadata             Json?
+  sourceKind           DatasetSourceKind
+  sourceTraceId        String?
   sourceExternalTraceId String?
-  sourceSpanId        String?
-  inputRetentionMode  PayloadRetention?
-  outputRetentionMode PayloadRetention?
-  createdAt           DateTime          @default(now())
-  datasetId           String
-  dataset             Dataset           @relation(fields: [datasetId], references: [id], onDelete: Cascade)
-  sourceTrace         Trace?            @relation("TraceDatasetRows", fields: [sourceTraceId], references: [id], onDelete: SetNull)
+  sourceSpanId         String?
+  inputRetentionMode   PayloadRetention?
+  outputRetentionMode  PayloadRetention?
+  createdAt            DateTime           @default(now())
+  datasetId            String
+  dataset              Dataset            @relation(fields: [datasetId], references: [id], onDelete: Cascade)
+  sourceTrace          Trace?             @relation("TraceDatasetRows", fields: [sourceTraceId], references: [id], onDelete: SetNull)
+  manualEvalRunItems   ManualEvalRunItem[]
 
   @@unique([datasetId, position])
   @@index([datasetId, createdAt])
   @@index([sourceTraceId])
+}
+
+model ManualEval {
+  id                 String          @id @default(cuid())
+  name               String
+  description        String?
+  reviewerInstructions String?
+  runCount           Int             @default(0)
+  totalRows          Int             @default(0)
+  reviewedRows       Int             @default(0)
+  pendingRows        Int             @default(0)
+  passCount          Int             @default(0)
+  failCount          Int             @default(0)
+  averageScore       Decimal         @default(0) @db.Decimal(6, 3)
+  criterionAverages  Json?
+  createdAt          DateTime        @default(now())
+  updatedAt          DateTime        @updatedAt
+  projectId          String
+  datasetId          String
+  project            Project         @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  dataset            Dataset         @relation(fields: [datasetId], references: [id], onDelete: Cascade)
+  criteria           ManualEvalCriterion[]
+  runs               ManualEvalRun[]
+
+  @@unique([datasetId, name])
+  @@index([projectId, updatedAt])
+  @@index([datasetId, updatedAt])
+}
+
+model ManualEvalCriterion {
+  id          String     @id @default(cuid())
+  position    Int
+  label       String
+  description String?
+  weight      Int        @default(1)
+  createdAt   DateTime   @default(now())
+  updatedAt   DateTime   @updatedAt
+  manualEvalId String
+  manualEval  ManualEval @relation(fields: [manualEvalId], references: [id], onDelete: Cascade)
+
+  @@unique([manualEvalId, position])
+}
+
+model ManualEvalRun {
+  id                String              @id @default(cuid())
+  status            ManualEvalRunStatus @default(IN_PROGRESS)
+  totalRows         Int                 @default(0)
+  reviewedRows      Int                 @default(0)
+  pendingRows       Int                 @default(0)
+  passCount         Int                 @default(0)
+  failCount         Int                 @default(0)
+  averageScore      Decimal             @default(0) @db.Decimal(6, 3)
+  criterionAverages Json?
+  completedAt       DateTime?
+  createdAt         DateTime            @default(now())
+  updatedAt         DateTime            @updatedAt
+  manualEvalId      String
+  datasetId         String
+  createdByUserId   String
+  manualEval        ManualEval          @relation(fields: [manualEvalId], references: [id], onDelete: Cascade)
+  dataset           Dataset             @relation(fields: [datasetId], references: [id], onDelete: Cascade)
+  createdBy         User                @relation("ManualEvalRunCreator", fields: [createdByUserId], references: [id], onDelete: Cascade)
+  items             ManualEvalRunItem[]
+
+  @@index([manualEvalId, createdAt])
+  @@index([datasetId, createdAt])
+}
+
+model ManualEvalRunItem {
+  id              String            @id @default(cuid())
+  position        Int
+  verdict         ManualEvalVerdict?
+  notes           String?           @db.Text
+  overallScore    Decimal?          @db.Decimal(6, 3)
+  criterionScores Json?
+  reviewedAt      DateTime?
+  createdAt       DateTime          @default(now())
+  updatedAt       DateTime          @updatedAt
+  runId           String
+  datasetRowId    String
+  reviewerUserId  String?
+  run             ManualEvalRun     @relation(fields: [runId], references: [id], onDelete: Cascade)
+  datasetRow      DatasetRow        @relation(fields: [datasetRowId], references: [id], onDelete: Cascade)
+  reviewer        User?             @relation("ManualEvalReviewer", fields: [reviewerUserId], references: [id], onDelete: SetNull)
+
+  @@unique([runId, position])
+  @@unique([runId, datasetRowId])
+  @@index([datasetRowId])
+  @@index([reviewerUserId])
 }
 
 model PromptPayload {

--- a/packages/ts/types/src/index.ts
+++ b/packages/ts/types/src/index.ts
@@ -92,6 +92,84 @@ export interface TraceDatasetExportInput {
   metadata?: JsonObject;
 }
 
+export type ManualEvalVerdict = "pass" | "fail";
+
+export type ManualEvalRunStatus = "in_progress" | "completed";
+
+export interface ManualEvalCriterion {
+  id: string;
+  position: number;
+  label: string;
+  description?: string;
+  weight: number;
+}
+
+export interface ManualEvalCriterionAverage {
+  criterionId: string;
+  label: string;
+  weight: number;
+  reviewedRows: number;
+  averageScore?: number;
+}
+
+export interface ManualEvalMetrics {
+  totalRows: number;
+  reviewedRows: number;
+  pendingRows: number;
+  passCount: number;
+  failCount: number;
+  passRate: number;
+  failRate: number;
+  overallAverageScore?: number;
+  criterionAverages: ManualEvalCriterionAverage[];
+}
+
+export interface ManualEval {
+  id: string;
+  projectId: string;
+  datasetId: string;
+  name: string;
+  description?: string;
+  reviewerInstructions?: string;
+  runCount: number;
+  metrics: ManualEvalMetrics;
+  criteria: ManualEvalCriterion[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ManualEvalRunItemCriterionScore {
+  criterionId: string;
+  score: number;
+}
+
+export interface ManualEvalRunItem {
+  id: string;
+  runId: string;
+  datasetRowId: string;
+  position: number;
+  row: DatasetRowSnapshot;
+  verdict?: ManualEvalVerdict;
+  notes?: string;
+  overallScore?: number;
+  criterionScores: ManualEvalRunItemCriterionScore[];
+  reviewerUserId?: string;
+  reviewedAt?: string;
+}
+
+export interface ManualEvalRun {
+  id: string;
+  manualEvalId: string;
+  datasetId: string;
+  status: ManualEvalRunStatus;
+  createdByUserId: string;
+  metrics: ManualEvalMetrics;
+  items: ManualEvalRunItem[];
+  completedAt?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
 export interface ControlPlaneProject {
   id: string;
   name: string;


### PR DESCRIPTION
## Linked Issue

- Closes #18

## Summary

- add Prisma models for manual eval definitions, runs, and run items on top of project datasets
- add shared `@captar/types` contracts for manual evals, runs, items, verdicts, and metrics
- add platform-side manual eval service helpers plus a pure metric engine for score aggregation and summary persistence

## Validation

- [ ] `pnpm lint`
- [ ] `pnpm test`
- [x] Additional validation noted below

Additional validation:
- [x] `pnpm db:generate`
- [x] `pnpm --filter @captar/types build`
- [x] `pnpm --filter @captar/platform lint`
- [x] `pnpm --filter @captar/platform test`

## Risk and Rollback

- Risk level: Medium, because this adds new Prisma models and persistence paths that later UI routes will rely on.
- Rollback plan: Revert this branch before merge or revert the merge commit to remove the manual eval schema and service layer together.

## Screenshots

- [ ] UI change with screenshots attached
- [x] No UI change
