### PR TITLE
feat: add manual eval workflows

### DIFF
--- a/apps/platform/app/api/projects/[projectId]/evals/[evalId]/route.ts
+++ b/apps/platform/app/api/projects/[projectId]/evals/[evalId]/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+
+import { auth } from "../../../../../../auth";
+import { getProjectManualEvalById } from "../../../../../../lib/platform";
+
+export async function GET(
+  _request: Request,
+  context: { params: Promise<{ projectId: string; evalId: string }> },
+) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { projectId, evalId } = await context.params;
+  const manualEval = await getProjectManualEvalById(projectId, evalId, session.user.id);
+
+  if (!manualEval) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  return NextResponse.json(manualEval);
+}

--- a/apps/platform/app/api/projects/[projectId]/evals/[evalId]/runs/[runId]/items/[itemId]/route.ts
+++ b/apps/platform/app/api/projects/[projectId]/evals/[evalId]/runs/[runId]/items/[itemId]/route.ts
@@ -1,0 +1,66 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import { auth } from "../../../../../../../../../../auth";
+import { saveManualEvalRunItemReview } from "../../../../../../../../../../lib/platform";
+
+const reviewSchema = z.object({
+  verdict: z.enum(["pass", "fail"]),
+  notes: z.string().max(4000).optional().nullable(),
+  criterionScores: z
+    .array(
+      z.object({
+        criterionId: z.string().min(1),
+        score: z.number().int().min(1).max(5),
+      }),
+    )
+    .min(1),
+});
+
+export async function PUT(
+  request: Request,
+  context: {
+    params: Promise<{
+      projectId: string;
+      evalId: string;
+      runId: string;
+      itemId: string;
+    }>;
+  },
+) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = await request.json();
+  const parsed = reviewSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid review payload." }, { status: 400 });
+  }
+
+  const { projectId, evalId, runId, itemId } = await context.params;
+
+  try {
+    const result = await saveManualEvalRunItemReview(
+      projectId,
+      evalId,
+      runId,
+      itemId,
+      session.user.id,
+      parsed.data,
+    );
+
+    if (!result) {
+      return NextResponse.json({ error: "Run item not found." }, { status: 404 });
+    }
+
+    return NextResponse.json(result);
+  } catch (error) {
+    if (error instanceof Error) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+
+    throw error;
+  }
+}

--- a/apps/platform/app/api/projects/[projectId]/evals/[evalId]/runs/[runId]/route.ts
+++ b/apps/platform/app/api/projects/[projectId]/evals/[evalId]/runs/[runId]/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+
+import { auth } from "../../../../../../../../auth";
+import { getProjectManualEvalRunById } from "../../../../../../../../lib/platform";
+
+export async function GET(
+  _request: Request,
+  context: { params: Promise<{ projectId: string; evalId: string; runId: string }> },
+) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { projectId, evalId, runId } = await context.params;
+  const run = await getProjectManualEvalRunById(projectId, evalId, runId, session.user.id);
+
+  if (!run) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  return NextResponse.json(run);
+}

--- a/apps/platform/app/api/projects/[projectId]/evals/[evalId]/runs/route.ts
+++ b/apps/platform/app/api/projects/[projectId]/evals/[evalId]/runs/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+
+import { auth } from "../../../../../../../auth";
+import { createProjectManualEvalRun } from "../../../../../../../lib/platform";
+
+export async function POST(
+  _request: Request,
+  context: { params: Promise<{ projectId: string; evalId: string }> },
+) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { projectId, evalId } = await context.params;
+
+  try {
+    const run = await createProjectManualEvalRun(projectId, evalId, session.user.id);
+
+    if (!run) {
+      return NextResponse.json({ error: "Manual eval not found." }, { status: 404 });
+    }
+
+    return NextResponse.json({ run });
+  } catch (error) {
+    if (error instanceof Error) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+
+    throw error;
+  }
+}

--- a/apps/platform/app/api/projects/[projectId]/evals/route.ts
+++ b/apps/platform/app/api/projects/[projectId]/evals/route.ts
@@ -1,0 +1,84 @@
+import { NextResponse } from "next/server";
+import { Prisma } from "@prisma/client";
+import { z } from "zod";
+
+import { auth } from "../../../../../auth";
+import {
+  createProjectManualEval,
+  getProjectById,
+  listProjectManualEvals,
+} from "../../../../../lib/platform";
+
+const criterionSchema = z.object({
+  label: z.string().min(1).max(80),
+  description: z.string().max(600).optional().nullable(),
+  weight: z.number().int().min(1).max(10).optional(),
+});
+
+const manualEvalSchema = z.object({
+  datasetId: z.string().min(1),
+  name: z.string().min(2).max(80),
+  description: z.string().max(1000).optional().nullable(),
+  reviewerInstructions: z.string().max(4000).optional().nullable(),
+  criteria: z.array(criterionSchema).min(1),
+});
+
+export async function GET(
+  _request: Request,
+  context: { params: Promise<{ projectId: string }> },
+) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { projectId } = await context.params;
+  const project = await getProjectById(projectId, session.user.id);
+  if (!project) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  const manualEvals = await listProjectManualEvals(project.id, session.user.id);
+  return NextResponse.json({ manualEvals });
+}
+
+export async function POST(
+  request: Request,
+  context: { params: Promise<{ projectId: string }> },
+) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { projectId } = await context.params;
+  const project = await getProjectById(projectId, session.user.id);
+  if (!project) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  const body = await request.json();
+  const parsed = manualEvalSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid manual eval input." }, { status: 400 });
+  }
+
+  try {
+    const manualEval = await createProjectManualEval(project.id, session.user.id, parsed.data);
+
+    if (!manualEval) {
+      return NextResponse.json({ error: "Dataset not found." }, { status: 404 });
+    }
+
+    return NextResponse.json({ manualEval });
+  } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") {
+      return NextResponse.json(
+        { error: "A manual eval with this name already exists for the dataset." },
+        { status: 409 },
+      );
+    }
+
+    throw error;
+  }
+}

--- a/apps/platform/app/projects/[projectId]/datasets/[datasetId]/page.tsx
+++ b/apps/platform/app/projects/[projectId]/datasets/[datasetId]/page.tsx
@@ -5,11 +5,12 @@ import type { JsonValue } from "@captar/types";
 
 import { AppShell } from "../../../../../components/app-shell";
 import { DatasetImportForm } from "../../../../../components/dataset-import-form";
+import { ManualEvalCreateForm } from "../../../../../components/manual-eval-create-form";
 import { Badge } from "../../../../../components/ui/badge";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../../../../../components/ui/card";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../../../../../components/ui/table";
 import { requireUser } from "../../../../../lib/auth-guard";
-import { getProjectById, getProjectDatasetById } from "../../../../../lib/platform";
+import { getProjectById, getProjectDatasetById, listDatasetManualEvals } from "../../../../../lib/platform";
 
 export const dynamic = "force-dynamic";
 
@@ -28,6 +29,8 @@ export default async function DatasetDetailPage({
   if (!project || !dataset) {
     notFound();
   }
+
+  const manualEvals = await listDatasetManualEvals(projectId, datasetId, user.id);
 
   return (
     <AppShell userName={user.email}>
@@ -51,8 +54,17 @@ export default async function DatasetDetailPage({
               <p className="text-sm text-slate-400">
                 {dataset.description ?? "No description yet."}
               </p>
+              <p className="text-sm text-slate-500">
+                {manualEvals.length} manual eval(s) currently use this dataset.
+              </p>
             </div>
             <div className="flex flex-wrap gap-3">
+              <Link
+                className="inline-flex items-center rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 transition hover:border-cyan-400/40 hover:text-cyan-200"
+                href={`/projects/${project.id}/evals`}
+              >
+                Open evals
+              </Link>
               <DatasetExportLink
                 href={`/api/projects/${project.id}/datasets/${dataset.id}/export?format=json`}
                 label="Export JSON"
@@ -75,74 +87,123 @@ export default async function DatasetDetailPage({
         </Card>
 
         <div className="grid gap-6 xl:grid-cols-[380px_minmax(0,1fr)]">
-          <DatasetImportForm projectId={project.id} datasetId={dataset.id} />
+          <div className="grid gap-6">
+            <ManualEvalCreateForm projectId={project.id} datasetId={dataset.id} />
+            <DatasetImportForm projectId={project.id} datasetId={dataset.id} />
+          </div>
 
-          <Card>
-            <CardHeader>
-              <CardTitle>Dataset rows</CardTitle>
-              <CardDescription>
-                Rows stay append-only in v1 so trace exports and file imports remain auditable.
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              {dataset.rows.length ? (
-                <Table>
-                  <TableHeader>
-                    <TableRow>
-                      <TableHead>#</TableHead>
-                      <TableHead>Input</TableHead>
-                      <TableHead>Output</TableHead>
-                      <TableHead>Source</TableHead>
-                      <TableHead>Retention</TableHead>
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {dataset.rows.map((row) => (
-                      <TableRow key={row.id}>
-                        <TableCell className="font-mono text-xs">{row.position}</TableCell>
-                        <TableCell>
-                          <RowPayload value={row.input} />
-                        </TableCell>
-                        <TableCell>
-                          <RowPayload value={row.output ?? null} emptyLabel="No output" />
-                        </TableCell>
-                        <TableCell>
-                          <div className="space-y-2 text-sm text-slate-300">
-                            <Badge>{row.source?.kind ?? "file_import"}</Badge>
-                            {row.source?.traceId ? (
-                              <Link
-                                className="block text-cyan-300 hover:text-cyan-200"
-                                href={`/traces/${row.source.traceId}`}
-                              >
-                                Trace {row.source.externalTraceId ?? row.source.traceId}
-                              </Link>
-                            ) : (
-                              <p>Imported from file</p>
-                            )}
-                            {row.metadata ? (
-                              <pre className="overflow-x-auto rounded-lg border border-slate-800 bg-slate-950 p-2 text-xs text-slate-400">
-                                {JSON.stringify(row.metadata, null, 2)}
-                              </pre>
-                            ) : null}
-                          </div>
-                        </TableCell>
-                        <TableCell>
-                          <div className="space-y-2 text-sm text-slate-300">
-                            <p>Input: {row.source?.inputRetentionMode ?? "n/a"}</p>
-                            <p>Output: {row.source?.outputRetentionMode ?? "n/a"}</p>
-                          </div>
-                        </TableCell>
+          <div className="grid gap-6">
+            <Card>
+              <CardHeader>
+                <CardTitle>Manual evals on this dataset</CardTitle>
+                <CardDescription>
+                  Create one rubric per review workflow, then launch runs that snapshot these rows.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                {manualEvals.length ? (
+                  manualEvals.map((manualEval) => (
+                    <div
+                      key={manualEval.id}
+                      className="rounded-xl border border-slate-800 bg-slate-900/60 p-4"
+                    >
+                      <div className="flex items-start justify-between gap-4">
+                        <div>
+                          <Link
+                            className="font-medium text-cyan-300 hover:text-cyan-200"
+                            href={`/projects/${project.id}/evals/${manualEval.id}`}
+                          >
+                            {manualEval.name}
+                          </Link>
+                          <p className="mt-1 text-sm text-slate-400">
+                            {manualEval.description ?? "No description yet."}
+                          </p>
+                        </div>
+                        <Badge>{manualEval.runCount} runs</Badge>
+                      </div>
+                      <div className="mt-3 flex flex-wrap gap-3 text-xs text-slate-400">
+                        <span>
+                          Reviewed {manualEval.metrics.reviewedRows}/{manualEval.metrics.totalRows}
+                        </span>
+                        <span>Pass rate {(manualEval.metrics.passRate * 100).toFixed(1)}%</span>
+                      </div>
+                    </div>
+                  ))
+                ) : (
+                  <div className="rounded-xl border border-dashed border-slate-700 bg-slate-950/60 p-6 text-sm text-slate-400">
+                    No manual evals yet. Create one from the form to the left.
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>Dataset rows</CardTitle>
+                <CardDescription>
+                  Rows stay append-only in v1 so trace exports, imports, and manual eval runs remain auditable.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                {dataset.rows.length ? (
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>#</TableHead>
+                        <TableHead>Input</TableHead>
+                        <TableHead>Output</TableHead>
+                        <TableHead>Source</TableHead>
+                        <TableHead>Retention</TableHead>
                       </TableRow>
-                    ))}
-                  </TableBody>
-                </Table>
-              ) : (
-                <div className="rounded-xl border border-dashed border-slate-700 bg-slate-950/60 p-6 text-sm text-slate-400">
-                  No rows yet. Import a file or export a trace into this dataset.
-                </div>
-              )}
-            </CardContent>
-          </Card>
+                    </TableHeader>
+                    <TableBody>
+                      {dataset.rows.map((row) => (
+                        <TableRow key={row.id}>
+                          <TableCell className="font-mono text-xs">{row.position}</TableCell>
+                          <TableCell>
+                            <RowPayload value={row.input} />
+                          </TableCell>
+                          <TableCell>
+                            <RowPayload value={row.output ?? null} emptyLabel="No output" />
+                          </TableCell>
+                          <TableCell>
+                            <div className="space-y-2 text-sm text-slate-300">
+                              <Badge>{row.source?.kind ?? "file_import"}</Badge>
+                              {row.source?.traceId ? (
+                                <Link
+                                  className="block text-cyan-300 hover:text-cyan-200"
+                                  href={`/traces/${row.source.traceId}`}
+                                >
+                                  Trace {row.source.externalTraceId ?? row.source.traceId}
+                                </Link>
+                              ) : (
+                                <p>Imported from file</p>
+                              )}
+                              {row.metadata ? (
+                                <pre className="overflow-x-auto rounded-lg border border-slate-800 bg-slate-950 p-2 text-xs text-slate-400">
+                                  {JSON.stringify(row.metadata, null, 2)}
+                                </pre>
+                              ) : null}
+                            </div>
+                          </TableCell>
+                          <TableCell>
+                            <div className="space-y-2 text-sm text-slate-300">
+                              <p>Input: {row.source?.inputRetentionMode ?? "n/a"}</p>
+                              <p>Output: {row.source?.outputRetentionMode ?? "n/a"}</p>
+                            </div>
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                ) : (
+                  <div className="rounded-xl border border-dashed border-slate-700 bg-slate-950/60 p-6 text-sm text-slate-400">
+                    No rows yet. Import a file or export a trace into this dataset.
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          </div>
         </div>
       </div>
     </AppShell>

--- a/apps/platform/app/projects/[projectId]/evals/[evalId]/page.tsx
+++ b/apps/platform/app/projects/[projectId]/evals/[evalId]/page.tsx
@@ -1,0 +1,184 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import { AppShell } from "../../../../../components/app-shell";
+import { ManualEvalStartRunButton } from "../../../../../components/manual-eval-start-run-button";
+import { Badge } from "../../../../../components/ui/badge";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../../../../../components/ui/card";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../../../../../components/ui/table";
+import { requireUser } from "../../../../../lib/auth-guard";
+import { getProjectManualEvalById } from "../../../../../lib/platform";
+
+export const dynamic = "force-dynamic";
+
+export default async function ManualEvalDetailPage({
+  params,
+}: {
+  params: Promise<{ projectId: string; evalId: string }>;
+}) {
+  const user = await requireUser();
+  const { projectId, evalId } = await params;
+  const payload = await getProjectManualEvalById(projectId, evalId, user.id);
+
+  if (!payload) {
+    notFound();
+  }
+
+  const { manualEval, dataset, runs } = payload;
+
+  return (
+    <AppShell userName={user.email}>
+      <div className="grid gap-6">
+        <Card>
+          <CardHeader className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+            <div className="space-y-2">
+              <div className="flex items-center gap-2">
+                <CardTitle>{manualEval.name}</CardTitle>
+                <Badge>{manualEval.runCount} runs</Badge>
+              </div>
+              <CardDescription>
+                Manual eval backed by dataset{" "}
+                <Link
+                  className="text-cyan-300 hover:text-cyan-200"
+                  href={`/projects/${projectId}/datasets/${dataset.id}`}
+                >
+                  {dataset.name}
+                </Link>
+              </CardDescription>
+              <p className="text-sm text-slate-400">
+                {manualEval.description ?? "No description yet."}
+              </p>
+            </div>
+            <div className="space-y-2">
+              <ManualEvalStartRunButton
+                projectId={projectId}
+                manualEvalId={manualEval.id}
+                disabled={!dataset.rows.length}
+              />
+              <Link
+                className="block text-sm text-cyan-300 hover:text-cyan-200"
+                href={`/projects/${projectId}/evals`}
+              >
+                View all evals
+              </Link>
+            </div>
+          </CardHeader>
+          <CardContent className="grid gap-4 md:grid-cols-4">
+            <MetricCard label="Dataset rows" value={String(dataset.rowCount)} />
+            <MetricCard label="Reviewed" value={String(manualEval.metrics.reviewedRows)} />
+            <MetricCard label="Pending" value={String(manualEval.metrics.pendingRows)} />
+            <MetricCard
+              label="Average score"
+              value={
+                manualEval.metrics.overallAverageScore != null
+                  ? manualEval.metrics.overallAverageScore.toFixed(3)
+                  : "n/a"
+              }
+            />
+          </CardContent>
+        </Card>
+
+        <div className="grid gap-6 xl:grid-cols-[minmax(0,1.1fr)_minmax(320px,0.9fr)]">
+          <Card>
+            <CardHeader>
+              <CardTitle>Rubric</CardTitle>
+              <CardDescription>
+                Reviewers score each row against these weighted criteria.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {manualEval.reviewerInstructions ? (
+                <div className="rounded-xl border border-slate-800 bg-slate-900/60 p-4 text-sm text-slate-300">
+                  {manualEval.reviewerInstructions}
+                </div>
+              ) : null}
+
+              {manualEval.criteria.map((criterion) => {
+                const metric = manualEval.metrics.criterionAverages.find(
+                  (entry) => entry.criterionId === criterion.id,
+                );
+
+                return (
+                  <div
+                    key={criterion.id}
+                    className="rounded-xl border border-slate-800 bg-slate-900/60 p-4"
+                  >
+                    <div className="flex items-center justify-between gap-4">
+                      <div>
+                        <p className="font-medium">{criterion.label}</p>
+                        <p className="mt-1 text-sm text-slate-400">
+                          {criterion.description ?? "No description provided."}
+                        </p>
+                      </div>
+                      <div className="text-right text-sm text-slate-300">
+                        <p>Weight {criterion.weight}</p>
+                        <p>
+                          Avg {metric?.averageScore != null ? metric.averageScore.toFixed(3) : "n/a"}
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Recent runs</CardTitle>
+              <CardDescription>
+                Each run freezes the dataset membership present at kickoff.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              {runs.length ? (
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Status</TableHead>
+                      <TableHead>Reviewed</TableHead>
+                      <TableHead>Pass rate</TableHead>
+                      <TableHead>Started</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {runs.map((run) => (
+                      <TableRow key={run.id}>
+                        <TableCell>
+                          <Link
+                            className="font-medium text-cyan-300 hover:text-cyan-200"
+                            href={`/projects/${projectId}/evals/${manualEval.id}/runs/${run.id}`}
+                          >
+                            {run.status}
+                          </Link>
+                        </TableCell>
+                        <TableCell>
+                          {run.metrics.reviewedRows}/{run.metrics.totalRows}
+                        </TableCell>
+                        <TableCell>{(run.metrics.passRate * 100).toFixed(1)}%</TableCell>
+                        <TableCell>{new Date(run.createdAt).toISOString()}</TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              ) : (
+                <div className="rounded-xl border border-dashed border-slate-700 bg-slate-950/60 p-6 text-sm text-slate-400">
+                  No runs yet. Start the first reviewer pass when this rubric looks right.
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </AppShell>
+  );
+}
+
+function MetricCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-xl border border-slate-800 bg-slate-900/60 p-4">
+      <p className="text-sm text-slate-400">{label}</p>
+      <p className="text-xl font-semibold">{value}</p>
+    </div>
+  );
+}

--- a/apps/platform/app/projects/[projectId]/evals/[evalId]/runs/[runId]/page.tsx
+++ b/apps/platform/app/projects/[projectId]/evals/[evalId]/runs/[runId]/page.tsx
@@ -1,0 +1,60 @@
+import { notFound } from "next/navigation";
+
+import { AppShell } from "../../../../../../../components/app-shell";
+import { ManualEvalRunReviewer } from "../../../../../../../components/manual-eval-run-reviewer";
+import { Badge } from "../../../../../../../components/ui/badge";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../../../../../../../components/ui/card";
+import { requireUser } from "../../../../../../../lib/auth-guard";
+import { getProjectManualEvalRunById } from "../../../../../../../lib/platform";
+
+export const dynamic = "force-dynamic";
+
+export default async function ManualEvalRunPage({
+  params,
+}: {
+  params: Promise<{ projectId: string; evalId: string; runId: string }>;
+}) {
+  const user = await requireUser();
+  const { projectId, evalId, runId } = await params;
+  const payload = await getProjectManualEvalRunById(projectId, evalId, runId, user.id);
+
+  if (!payload) {
+    notFound();
+  }
+
+  return (
+    <AppShell userName={user.email}>
+      <div className="grid gap-6">
+        <Card>
+          <CardHeader className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+            <div className="space-y-2">
+              <div className="flex items-center gap-2">
+                <CardTitle>{payload.manualEval.name}</CardTitle>
+                <Badge>{payload.run.status}</Badge>
+              </div>
+              <CardDescription>
+                Reviewer workspace for dataset{" "}
+                <span className="font-medium text-slate-200">{payload.dataset.name}</span>
+              </CardDescription>
+            </div>
+            <div className="text-right text-sm text-slate-400">
+              <p>Started {new Date(payload.run.createdAt).toISOString()}</p>
+              <p>
+                Completed{" "}
+                {payload.run.completedAt
+                  ? new Date(payload.run.completedAt).toISOString()
+                  : "in progress"}
+              </p>
+            </div>
+          </CardHeader>
+        </Card>
+
+        <ManualEvalRunReviewer
+          projectId={projectId}
+          manualEval={payload.manualEval}
+          initialRun={payload.run}
+        />
+      </div>
+    </AppShell>
+  );
+}

--- a/apps/platform/app/projects/[projectId]/evals/page.tsx
+++ b/apps/platform/app/projects/[projectId]/evals/page.tsx
@@ -1,0 +1,103 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import { AppShell } from "../../../../components/app-shell";
+import { Badge } from "../../../../components/ui/badge";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../../../../components/ui/card";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../../../../components/ui/table";
+import { requireUser } from "../../../../lib/auth-guard";
+import { getProjectById, listProjectManualEvals } from "../../../../lib/platform";
+
+export const dynamic = "force-dynamic";
+
+export default async function ProjectManualEvalsPage({
+  params,
+}: {
+  params: Promise<{ projectId: string }>;
+}) {
+  const user = await requireUser();
+  const { projectId } = await params;
+  const [project, manualEvals] = await Promise.all([
+    getProjectById(projectId, user.id),
+    listProjectManualEvals(projectId, user.id),
+  ]);
+
+  if (!project) {
+    notFound();
+  }
+
+  return (
+    <AppShell userName={user.email}>
+      <div className="grid gap-6">
+        <Card>
+          <CardHeader className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+            <div className="space-y-2">
+              <div className="flex items-center gap-2">
+                <CardTitle>Manual evals</CardTitle>
+                <Badge>{project._count.manualEvals}</Badge>
+              </div>
+              <CardDescription>
+                Offline reviewer workflows for project{" "}
+                <span className="font-medium text-slate-200">{project.name}</span>.
+              </CardDescription>
+            </div>
+            <Link
+              className="text-sm text-cyan-300 hover:text-cyan-200"
+              href={`/projects/${project.id}`}
+            >
+              Back to project
+            </Link>
+          </CardHeader>
+          <CardContent>
+            {manualEvals.length ? (
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Name</TableHead>
+                    <TableHead>Dataset</TableHead>
+                    <TableHead>Runs</TableHead>
+                    <TableHead>Reviewed</TableHead>
+                    <TableHead>Pass rate</TableHead>
+                    <TableHead>Updated</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {manualEvals.map((manualEval) => (
+                    <TableRow key={manualEval.id}>
+                      <TableCell>
+                        <Link
+                          className="font-medium text-cyan-300 hover:text-cyan-200"
+                          href={`/projects/${project.id}/evals/${manualEval.id}`}
+                        >
+                          {manualEval.name}
+                        </Link>
+                      </TableCell>
+                      <TableCell>
+                        <Link
+                          className="text-slate-300 hover:text-slate-100"
+                          href={`/projects/${project.id}/datasets/${manualEval.dataset.id}`}
+                        >
+                          {manualEval.dataset.name}
+                        </Link>
+                      </TableCell>
+                      <TableCell>{manualEval.runCount}</TableCell>
+                      <TableCell>
+                        {manualEval.metrics.reviewedRows}/{manualEval.metrics.totalRows}
+                      </TableCell>
+                      <TableCell>{(manualEval.metrics.passRate * 100).toFixed(1)}%</TableCell>
+                      <TableCell>{new Date(manualEval.updatedAt).toISOString()}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            ) : (
+              <div className="rounded-xl border border-dashed border-slate-700 bg-slate-950/60 p-6 text-sm text-slate-400">
+                No manual evals yet. Open a dataset and create one from its rows.
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </AppShell>
+  );
+}

--- a/apps/platform/app/projects/[projectId]/page.tsx
+++ b/apps/platform/app/projects/[projectId]/page.tsx
@@ -42,7 +42,7 @@ export default async function ProjectDetailPage({
             </div>
             <HookCreateDialog projectId={project.id} />
           </CardHeader>
-          <CardContent className="grid gap-4 md:grid-cols-4">
+          <CardContent className="grid gap-4 md:grid-cols-5">
             <div className="rounded-xl border border-slate-800 bg-slate-900/60 p-4">
               <p className="text-sm text-slate-400">Hook connections</p>
               <p className="text-2xl font-semibold">{project._count.hooks}</p>
@@ -58,6 +58,10 @@ export default async function ProjectDetailPage({
             <div className="rounded-xl border border-slate-800 bg-slate-900/60 p-4">
               <p className="text-sm text-slate-400">Datasets</p>
               <p className="text-2xl font-semibold">{project._count.datasets}</p>
+            </div>
+            <div className="rounded-xl border border-slate-800 bg-slate-900/60 p-4">
+              <p className="text-sm text-slate-400">Manual evals</p>
+              <p className="text-2xl font-semibold">{project._count.manualEvals}</p>
             </div>
           </CardContent>
         </Card>
@@ -152,6 +156,15 @@ export default async function ProjectDetailPage({
                         </div>
                         <Badge>{dataset.rowCount} rows</Badge>
                       </div>
+                      <div className="mt-3 flex items-center justify-between gap-4 text-xs text-slate-400">
+                        <span>{dataset._count.manualEvals} manual eval(s)</span>
+                        <Link
+                          className="text-cyan-300 hover:text-cyan-200"
+                          href={`/projects/${project.id}/datasets/${dataset.id}`}
+                        >
+                          Open dataset
+                        </Link>
+                      </div>
                     </div>
                   ))
                 ) : (
@@ -159,6 +172,31 @@ export default async function ProjectDetailPage({
                     No datasets yet. Export traces or import files from the dataset page.
                   </div>
                 )}
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <div className="flex items-start justify-between gap-4">
+                  <div>
+                    <CardTitle>Manual evals</CardTitle>
+                    <CardDescription>
+                      Score dataset rows offline before online evaluators land.
+                    </CardDescription>
+                  </div>
+                  <Link
+                    className="text-sm text-cyan-300 hover:text-cyan-200"
+                    href={`/projects/${project.id}/evals`}
+                  >
+                    Open evals
+                  </Link>
+                </div>
+              </CardHeader>
+              <CardContent className="space-y-2 text-sm text-slate-300">
+                <p>{project._count.manualEvals} manual eval(s) created in this project.</p>
+                <p className="text-slate-400">
+                  Start from a dataset to define a rubric, then launch reviewer runs that snapshot row membership.
+                </p>
               </CardContent>
             </Card>
 
@@ -181,7 +219,7 @@ export default async function ProjectDetailPage({
                 </div>
                 <div className="flex items-start gap-3">
                   <Database className="mt-0.5 h-4 w-4 text-cyan-300" />
-                  <p>Datasets stay project-scoped so traces can become reusable rows before evals land.</p>
+                  <p>Datasets stay project-scoped so traces can become reusable rows before manual evals and later automation land.</p>
                 </div>
                 <div className="flex items-start gap-3">
                   <ShieldCheck className="mt-0.5 h-4 w-4 text-cyan-300" />

--- a/apps/platform/components/manual-eval-create-form.tsx
+++ b/apps/platform/components/manual-eval-create-form.tsx
@@ -1,0 +1,238 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+import { Button } from "./ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "./ui/card";
+import { Input } from "./ui/input";
+import { Label } from "./ui/label";
+import { Textarea } from "./ui/textarea";
+
+interface CriterionDraft {
+  label: string;
+  description: string;
+  weight: string;
+}
+
+const defaultCriteria = (): CriterionDraft[] => [
+  {
+    label: "Accuracy",
+    description: "Did the output answer the prompt correctly?",
+    weight: "2",
+  },
+  {
+    label: "Grounding",
+    description: "Was the answer supported by the available context?",
+    weight: "1",
+  },
+];
+
+export function ManualEvalCreateForm({
+  projectId,
+  datasetId,
+}: {
+  projectId: string;
+  datasetId: string;
+}) {
+  const router = useRouter();
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [reviewerInstructions, setReviewerInstructions] = useState("");
+  const [criteria, setCriteria] = useState<CriterionDraft[]>(defaultCriteria);
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const validCriteria = criteria.filter((criterion) => criterion.label.trim().length > 0);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Create manual eval</CardTitle>
+        <CardDescription>
+          Turn this dataset into a reviewer-led rubric so rows can be scored offline.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor="manual-eval-name">Name</Label>
+          <Input
+            id="manual-eval-name"
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            placeholder="refund-response-quality"
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="manual-eval-description">Description</Label>
+          <Textarea
+            id="manual-eval-description"
+            value={description}
+            onChange={(event) => setDescription(event.target.value)}
+            placeholder="Manual pass/fail review for refund and escalation traces."
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="manual-eval-reviewer-instructions">
+            Reviewer instructions
+          </Label>
+          <Textarea
+            id="manual-eval-reviewer-instructions"
+            value={reviewerInstructions}
+            onChange={(event) => setReviewerInstructions(event.target.value)}
+            placeholder="Review each row for correctness, policy fit, and whether the answer stays grounded in the available information."
+          />
+        </div>
+
+        <div className="space-y-3">
+          <div className="flex items-center justify-between gap-4">
+            <Label>Rubric criteria</Label>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => {
+                setCriteria((current) => [
+                  ...current,
+                  {
+                    label: "",
+                    description: "",
+                    weight: "1",
+                  },
+                ]);
+              }}
+            >
+              Add criterion
+            </Button>
+          </div>
+
+          {criteria.map((criterion, index) => (
+            <div
+              key={`${index}-${criterion.label}`}
+              className="rounded-xl border border-slate-800 bg-slate-900/60 p-4"
+            >
+              <div className="grid gap-4">
+                <div className="space-y-2">
+                  <Label htmlFor={`criterion-label-${index}`}>Label</Label>
+                  <Input
+                    id={`criterion-label-${index}`}
+                    value={criterion.label}
+                    onChange={(event) =>
+                      setCriteria((current) =>
+                        current.map((entry, entryIndex) =>
+                          entryIndex === index
+                            ? { ...entry, label: event.target.value }
+                            : entry,
+                        ),
+                      )
+                    }
+                    placeholder="Accuracy"
+                  />
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor={`criterion-description-${index}`}>Description</Label>
+                  <Textarea
+                    id={`criterion-description-${index}`}
+                    value={criterion.description}
+                    onChange={(event) =>
+                      setCriteria((current) =>
+                        current.map((entry, entryIndex) =>
+                          entryIndex === index
+                            ? { ...entry, description: event.target.value }
+                            : entry,
+                        ),
+                      )
+                    }
+                    className="min-h-[88px]"
+                    placeholder="Does the answer match the expected outcome?"
+                  />
+                </div>
+
+                <div className="flex items-end gap-3">
+                  <div className="flex-1 space-y-2">
+                    <Label htmlFor={`criterion-weight-${index}`}>Weight</Label>
+                    <Input
+                      id={`criterion-weight-${index}`}
+                      type="number"
+                      min={1}
+                      max={10}
+                      value={criterion.weight}
+                      onChange={(event) =>
+                        setCriteria((current) =>
+                          current.map((entry, entryIndex) =>
+                            entryIndex === index
+                              ? { ...entry, weight: event.target.value }
+                              : entry,
+                          ),
+                        )
+                      }
+                    />
+                  </div>
+
+                  <Button
+                    type="button"
+                    variant="outline"
+                    disabled={criteria.length <= 1}
+                    onClick={() =>
+                      setCriteria((current) =>
+                        current.filter((_, entryIndex) => entryIndex !== index),
+                      )
+                    }
+                  >
+                    Remove
+                  </Button>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {error ? <p className="text-sm text-rose-300">{error}</p> : null}
+
+        <Button
+          disabled={isPending || !name.trim() || validCriteria.length === 0}
+          onClick={() => {
+            startTransition(async () => {
+              setError(null);
+
+              const response = await fetch(`/api/projects/${projectId}/evals`, {
+                method: "POST",
+                headers: { "content-type": "application/json" },
+                body: JSON.stringify({
+                  datasetId,
+                  name,
+                  description,
+                  reviewerInstructions,
+                  criteria: validCriteria.map((criterion) => ({
+                    label: criterion.label,
+                    description: criterion.description,
+                    weight: Number.parseInt(criterion.weight || "1", 10) || 1,
+                  })),
+                }),
+              });
+
+              if (!response.ok) {
+                const payload = (await response.json().catch(() => null)) as
+                  | { error?: string }
+                  | null;
+                setError(payload?.error ?? "Could not create manual eval.");
+                return;
+              }
+
+              const payload = (await response.json()) as {
+                manualEval: { id: string };
+              };
+
+              router.push(`/projects/${projectId}/evals/${payload.manualEval.id}`);
+              router.refresh();
+            });
+          }}
+        >
+          {isPending ? "Creating..." : "Create manual eval"}
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/platform/components/manual-eval-run-reviewer.tsx
+++ b/apps/platform/components/manual-eval-run-reviewer.tsx
@@ -1,0 +1,427 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState, useTransition } from "react";
+
+import type { JsonValue, ManualEval, ManualEvalRun, ManualEvalVerdict } from "@captar/types";
+
+import { Badge } from "./ui/badge";
+import { Button } from "./ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "./ui/card";
+import { Label } from "./ui/label";
+import { Textarea } from "./ui/textarea";
+
+const scoreOptions = [1, 2, 3, 4, 5];
+const selectClassName =
+  "flex h-10 w-full rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300";
+
+export function ManualEvalRunReviewer({
+  projectId,
+  manualEval,
+  initialRun,
+}: {
+  projectId: string;
+  manualEval: ManualEval;
+  initialRun: ManualEvalRun;
+}) {
+  const [run, setRun] = useState(initialRun);
+  const [selectedItemId, setSelectedItemId] = useState(initialRun.items[0]?.id ?? "");
+  const [verdict, setVerdict] = useState<ManualEvalVerdict | "">("");
+  const [notes, setNotes] = useState("");
+  const [criterionScores, setCriterionScores] = useState<Record<string, string>>({});
+  const [error, setError] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const selectedIndex = Math.max(
+    run.items.findIndex((item) => item.id === selectedItemId),
+    0,
+  );
+  const currentItem = run.items[selectedIndex];
+
+  useEffect(() => {
+    if (!currentItem) {
+      return;
+    }
+
+    setVerdict(currentItem.verdict ?? "");
+    setNotes(currentItem.notes ?? "");
+    setCriterionScores(
+      Object.fromEntries(
+        manualEval.criteria.map((criterion) => [
+          criterion.id,
+          String(
+            currentItem.criterionScores.find(
+              (entry) => entry.criterionId === criterion.id,
+            )?.score ?? "",
+          ),
+        ]),
+      ),
+    );
+  }, [currentItem, manualEval.criteria]);
+
+  if (!currentItem) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Run items</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-slate-400">This run has no dataset rows to review.</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const parsedScores = manualEval.criteria
+    .map((criterion) => {
+      const rawValue = criterionScores[criterion.id] ?? "";
+      const score = Number.parseInt(rawValue, 10);
+
+      return Number.isInteger(score)
+        ? { criterionId: criterion.id, score }
+        : null;
+    })
+    .filter((entry): entry is { criterionId: string; score: number } => Boolean(entry));
+
+  const canSave = Boolean(verdict) && parsedScores.length === manualEval.criteria.length;
+  const scorePreview = calculateScorePreview(
+    manualEval.criteria,
+    Object.fromEntries(parsedScores.map((entry) => [entry.criterionId, entry.score])),
+  );
+
+  return (
+    <div className="grid gap-6 xl:grid-cols-[300px_minmax(0,1fr)]">
+      <div className="space-y-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>Run progress</CardTitle>
+            <CardDescription>
+              Review rows in order or jump directly to anything still pending.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="grid gap-4 md:grid-cols-2 xl:grid-cols-1">
+            <MetricCard label="Rows" value={String(run.metrics.totalRows)} />
+            <MetricCard label="Reviewed" value={String(run.metrics.reviewedRows)} />
+            <MetricCard label="Pending" value={String(run.metrics.pendingRows)} />
+            <MetricCard
+              label="Average score"
+              value={
+                run.metrics.overallAverageScore != null
+                  ? run.metrics.overallAverageScore.toFixed(3)
+                  : "n/a"
+              }
+            />
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Rows</CardTitle>
+            <CardDescription>Pick a row to inspect, score, and save.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            {run.items.map((item) => (
+              <button
+                key={item.id}
+                className={`w-full rounded-xl border p-3 text-left transition ${
+                  item.id === currentItem.id
+                    ? "border-cyan-400/40 bg-cyan-400/10"
+                    : "border-slate-800 bg-slate-900/60 hover:border-slate-700"
+                }`}
+                onClick={() => {
+                  setError(null);
+                  setMessage(null);
+                  setSelectedItemId(item.id);
+                }}
+                type="button"
+              >
+                <div className="flex items-center justify-between gap-3">
+                  <div>
+                    <p className="font-medium text-slate-100">Row {item.position}</p>
+                    <p className="text-xs text-slate-400">
+                      {item.row.source?.kind === "trace_export"
+                        ? item.row.source.externalTraceId ?? item.row.source.traceId
+                        : "Imported row"}
+                    </p>
+                  </div>
+                  <Badge>{item.verdict ?? "pending"}</Badge>
+                </div>
+              </button>
+            ))}
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="grid gap-6">
+        <Card>
+          <CardHeader className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+            <div className="space-y-2">
+              <div className="flex items-center gap-2">
+                <CardTitle>Row {currentItem.position}</CardTitle>
+                <Badge>{currentItem.verdict ?? "pending"}</Badge>
+              </div>
+              <CardDescription>
+                Dataset row {currentItem.row.position} in manual eval{" "}
+                <span className="font-medium text-slate-200">{manualEval.name}</span>
+              </CardDescription>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                disabled={selectedIndex <= 0}
+                onClick={() => setSelectedItemId(run.items[selectedIndex - 1]?.id ?? currentItem.id)}
+              >
+                Previous
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                disabled={selectedIndex >= run.items.length - 1}
+                onClick={() => setSelectedItemId(run.items[selectedIndex + 1]?.id ?? currentItem.id)}
+              >
+                Next
+              </Button>
+            </div>
+          </CardHeader>
+          <CardContent className="grid gap-4 md:grid-cols-2">
+            <PayloadCard title="Input" value={currentItem.row.input} />
+            <PayloadCard title="Output" value={currentItem.row.output ?? null} emptyLabel="No output" />
+            <PayloadCard title="Metadata" value={currentItem.row.metadata ?? null} emptyLabel="No metadata" />
+            <Card className="border-slate-800 bg-slate-900/60">
+              <CardHeader>
+                <CardTitle className="text-base">Source</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-3 text-sm text-slate-300">
+                <Badge>{currentItem.row.source?.kind ?? "file_import"}</Badge>
+                {currentItem.row.source?.traceId ? (
+                  <Link
+                    className="block text-cyan-300 hover:text-cyan-200"
+                    href={`/traces/${currentItem.row.source.traceId}`}
+                  >
+                    Open source trace
+                  </Link>
+                ) : (
+                  <p>Imported from a dataset file.</p>
+                )}
+                <p>Input retention: {currentItem.row.source?.inputRetentionMode ?? "n/a"}</p>
+                <p>Output retention: {currentItem.row.source?.outputRetentionMode ?? "n/a"}</p>
+              </CardContent>
+            </Card>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Reviewer workspace</CardTitle>
+            <CardDescription>
+              Save one canonical review for this row. Scores use a 1-5 scale.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            {manualEval.reviewerInstructions ? (
+              <div className="rounded-xl border border-slate-800 bg-slate-900/60 p-4 text-sm text-slate-300">
+                {manualEval.reviewerInstructions}
+              </div>
+            ) : null}
+
+            <div className="space-y-3">
+              <Label>Verdict</Label>
+              <div className="flex flex-wrap gap-3">
+                <Button
+                  type="button"
+                  variant={verdict === "pass" ? "default" : "outline"}
+                  onClick={() => setVerdict("pass")}
+                >
+                  Pass
+                </Button>
+                <Button
+                  type="button"
+                  variant={verdict === "fail" ? "default" : "outline"}
+                  onClick={() => setVerdict("fail")}
+                >
+                  Fail
+                </Button>
+              </div>
+            </div>
+
+            <div className="grid gap-4 lg:grid-cols-2">
+              {manualEval.criteria.map((criterion) => (
+                <div
+                  key={criterion.id}
+                  className="rounded-xl border border-slate-800 bg-slate-900/60 p-4"
+                >
+                  <div className="space-y-2">
+                    <div className="flex items-center justify-between gap-3">
+                      <p className="font-medium">{criterion.label}</p>
+                      <Badge>weight {criterion.weight}</Badge>
+                    </div>
+                    {criterion.description ? (
+                      <p className="text-sm text-slate-400">{criterion.description}</p>
+                    ) : null}
+                    <select
+                      className={selectClassName}
+                      value={criterionScores[criterion.id] ?? ""}
+                      onChange={(event) =>
+                        setCriterionScores((current) => ({
+                          ...current,
+                          [criterion.id]: event.target.value,
+                        }))
+                      }
+                    >
+                      <option value="">Select score</option>
+                      {scoreOptions.map((score) => (
+                        <option key={score} value={String(score)}>
+                          {score}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="manual-eval-row-notes">Notes</Label>
+              <Textarea
+                id="manual-eval-row-notes"
+                value={notes}
+                onChange={(event) => setNotes(event.target.value)}
+                placeholder="Call out what made this row pass or fail, plus anything the team should fix next."
+              />
+            </div>
+
+            <div className="rounded-xl border border-slate-800 bg-slate-900/60 p-4 text-sm text-slate-300">
+              <p>
+                Score preview:{" "}
+                <span className="font-medium text-slate-100">
+                  {scorePreview != null ? scorePreview.toFixed(3) : "n/a"}
+                </span>
+              </p>
+              {currentItem.reviewedAt ? (
+                <p className="mt-2 text-slate-400">
+                  Last reviewed at {new Date(currentItem.reviewedAt).toISOString()}
+                </p>
+              ) : null}
+            </div>
+
+            {error ? <p className="text-sm text-rose-300">{error}</p> : null}
+            {message ? <p className="text-sm text-emerald-300">{message}</p> : null}
+
+            <Button
+              disabled={isPending || !canSave}
+              onClick={() => {
+                startTransition(async () => {
+                  setError(null);
+                  setMessage(null);
+
+                  const response = await fetch(
+                    `/api/projects/${projectId}/evals/${manualEval.id}/runs/${run.id}/items/${currentItem.id}`,
+                    {
+                      method: "PUT",
+                      headers: { "content-type": "application/json" },
+                      body: JSON.stringify({
+                        verdict,
+                        notes,
+                        criterionScores: parsedScores,
+                      }),
+                    },
+                  );
+
+                  if (!response.ok) {
+                    const payload = (await response.json().catch(() => null)) as
+                      | { error?: string }
+                      | null;
+                    setError(payload?.error ?? "Could not save row review.");
+                    return;
+                  }
+
+                  const payload = (await response.json()) as {
+                    run: ManualEvalRun;
+                  };
+                  setRun(payload.run);
+                  setMessage("Saved row review.");
+
+                  const refreshedIndex = payload.run.items.findIndex(
+                    (item) => item.id === currentItem.id,
+                  );
+                  const nextPending =
+                    payload.run.items
+                      .slice(refreshedIndex + 1)
+                      .find((item) => !item.verdict) ??
+                    payload.run.items.find((item) => !item.verdict);
+
+                  setSelectedItemId(nextPending?.id ?? currentItem.id);
+                });
+              }}
+            >
+              {isPending ? "Saving..." : "Save review"}
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}
+
+function MetricCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-xl border border-slate-800 bg-slate-900/60 p-4">
+      <p className="text-sm text-slate-400">{label}</p>
+      <p className="text-lg font-semibold">{value}</p>
+    </div>
+  );
+}
+
+function PayloadCard({
+  title,
+  value,
+  emptyLabel = "No value",
+}: {
+  title: string;
+  value: JsonValue | null;
+  emptyLabel?: string;
+}) {
+  return (
+    <Card className="border-slate-800 bg-slate-900/60">
+      <CardHeader>
+        <CardTitle className="text-base">{title}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {value == null ? (
+          <p className="text-sm text-slate-500">{emptyLabel}</p>
+        ) : (
+          <pre className="overflow-x-auto whitespace-pre-wrap rounded-lg border border-slate-800 bg-slate-950 p-3 text-xs text-slate-200">
+            {typeof value === "string" ? value : JSON.stringify(value, null, 2)}
+          </pre>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function calculateScorePreview(
+  criteria: ManualEval["criteria"],
+  scores: Record<string, number>,
+) {
+  let weightedTotal = 0;
+  let totalWeight = 0;
+
+  for (const criterion of criteria) {
+    const score = scores[criterion.id];
+
+    if (typeof score !== "number") {
+      continue;
+    }
+
+    weightedTotal += score * criterion.weight;
+    totalWeight += criterion.weight;
+  }
+
+  if (!totalWeight) {
+    return null;
+  }
+
+  return Number((weightedTotal / totalWeight).toFixed(3));
+}

--- a/apps/platform/components/manual-eval-start-run-button.tsx
+++ b/apps/platform/components/manual-eval-start-run-button.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+import { Button } from "./ui/button";
+
+export function ManualEvalStartRunButton({
+  projectId,
+  manualEvalId,
+  disabled,
+}: {
+  projectId: string;
+  manualEvalId: string;
+  disabled?: boolean;
+}) {
+  const router = useRouter();
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  return (
+    <div className="space-y-2">
+      <Button
+        disabled={disabled || isPending}
+        onClick={() => {
+          startTransition(async () => {
+            setError(null);
+
+            const response = await fetch(
+              `/api/projects/${projectId}/evals/${manualEvalId}/runs`,
+              {
+                method: "POST",
+              },
+            );
+
+            if (!response.ok) {
+              const payload = (await response.json().catch(() => null)) as
+                | { error?: string }
+                | null;
+              setError(payload?.error ?? "Could not start manual eval run.");
+              return;
+            }
+
+            const payload = (await response.json()) as {
+              run: { id: string };
+            };
+            router.push(
+              `/projects/${projectId}/evals/${manualEvalId}/runs/${payload.run.id}`,
+            );
+            router.refresh();
+          });
+        }}
+      >
+        {isPending ? "Starting..." : "Start run"}
+      </Button>
+      {error ? <p className="text-sm text-rose-300">{error}</p> : null}
+    </div>
+  );
+}

--- a/apps/platform/lib/platform.ts
+++ b/apps/platform/lib/platform.ts
@@ -887,6 +887,11 @@ export async function getProjectById(projectId: string, userId: string) {
           description: true,
           rowCount: true,
           updatedAt: true,
+          _count: {
+            select: {
+              manualEvals: true,
+            },
+          },
         },
         orderBy: { updatedAt: "desc" },
         take: 5,
@@ -896,6 +901,7 @@ export async function getProjectById(projectId: string, userId: string) {
           hooks: true,
           sessions: true,
           datasets: true,
+          manualEvals: true,
         },
       },
     },
@@ -1398,6 +1404,53 @@ export async function listProjectManualEvals(projectId: string, userId: string) 
   const manualEvals = await prisma.manualEval.findMany({
     where: {
       projectId,
+      project: {
+        members: {
+          some: { userId },
+        },
+      },
+    },
+    include: {
+      criteria: {
+        orderBy: { position: "asc" },
+      },
+      dataset: true,
+      runs: {
+        orderBy: { createdAt: "desc" },
+        take: 1,
+      },
+    },
+    orderBy: { updatedAt: "desc" },
+  });
+
+  return manualEvals.map((manualEval) => {
+    const snapshot = toManualEvalSnapshot(manualEval);
+
+    return {
+      ...snapshot,
+      dataset: toDatasetSnapshot(manualEval.dataset),
+      latestRun: manualEval.runs[0]
+        ? toManualEvalRunSnapshot({
+            ...manualEval.runs[0],
+            items: [],
+            manualEval: {
+              criteria: manualEval.criteria,
+            },
+          })
+        : null,
+    };
+  });
+}
+
+export async function listDatasetManualEvals(
+  projectId: string,
+  datasetId: string,
+  userId: string,
+) {
+  const manualEvals = await prisma.manualEval.findMany({
+    where: {
+      projectId,
+      datasetId,
       project: {
         members: {
           some: { userId },


### PR DESCRIPTION
## Linked Issue

- Closes #17

## Summary

- add authenticated platform routes for manual eval create/load/start-run/save-review flows
- add project, eval, and run pages plus the reviewer workspace for pass/fail and rubric scoring
- add dataset and project navigation so manual evals are discoverable from the existing trace -> dataset flow

## Validation

- [ ] `pnpm lint`
- [ ] `pnpm test`
- [x] Additional validation noted below

Additional validation:
- [x] `pnpm --filter @captar/platform lint`
- [x] `pnpm --filter @captar/platform test`

## Risk and Rollback

- Risk level: Medium, because this introduces new project routes and client-side review flows on top of the stacked core PR.
- Rollback plan: Revert this branch before merge or revert the merge commit after `#20` lands to remove the UI and route layer while keeping the core persistence work isolated.

## Screenshots

- [ ] UI change with screenshots attached
- [x] No UI change
