### PR TITLE
chore: document manual eval flow and add coverage

### DIFF
--- a/.ai/current-focus.md
+++ b/.ai/current-focus.md
@@ -2,25 +2,25 @@
 
 - Last updated: 2026-04-08
 - Umbrella issue: `#3` - V1 traces-first foundation, repo memory, and GitHub workflow
-- Active delivery issues: `#11`, `#12`, and `#13`
+- Active delivery issues: `#18`, `#17`, and `#19`
 - Delivery model: split issue-linked branches and pull requests instead of one large branch
 
 ## V1 priorities now
 
-- Turn traces into project-scoped datasets through the platform.
+- Turn project-scoped datasets into offline/manual eval workflows through the platform.
 - Keep the public SDK surface centered on `createCaptar()`, `wrapOpenAI()`, and `trackTool()`.
-- Keep eval execution out of scope until the dataset flow is stable.
+- Keep automated evaluators out of scope until the manual eval flow is stable.
 - Keep shared repo memory and GitHub workflow enforcement current as each split issue lands.
 
 ## Current split
 
-- `#11` dataset persistence, shared contracts, and backend helpers
-- `#12` platform dataset routes, pages, and trace export workflows
-- `#13` repo memory, docs, and dataset coverage
+- `#18` manual eval persistence, shared contracts, and backend helpers
+- `#17` platform manual eval routes, pages, and reviewer workflows
+- `#19` repo memory, docs, and manual eval coverage
 
 ## Explicitly not shipping in v1
 
-- Evals
+- Automated evaluators
 - Signals
 - SQL exploration
 - Alerts

--- a/.ai/github-backlog.md
+++ b/.ai/github-backlog.md
@@ -3,12 +3,12 @@
 ## Active
 
 - `#3` V1 traces-first foundation, repo memory, and GitHub workflow
-- `#11` Add dataset core persistence and shared dataset contracts
-- `#12` Add platform dataset import/export and trace export workflows
-- `#13` Document dataset flow and add dataset coverage
+- `#18` Add manual eval core persistence and shared contracts
+- `#17` Add platform manual eval workflows on dataset rows
+- `#19` Document manual eval flow and add coverage
 
 ## Next candidate issues
 
-- Design offline/manual evaluation runs on top of dataset rows
-- Define online evaluator model after dataset shape is settled
-- Add signals over trace and dataset activity after eval workflows exist
+- Define the online evaluator model after manual eval rubrics and run snapshots settle
+- Add signals over trace, dataset, and eval activity after reviewer workflows exist
+- Export eval results and summaries for downstream analysis or benchmarking

--- a/.ai/session-handoff.md
+++ b/.ai/session-handoff.md
@@ -4,8 +4,8 @@
 
 - Date: 2026-04-08
 - Umbrella issue: `#3`
-- Active milestone issues: `#11`, `#12`, `#13`
-- Goal: ship project-scoped datasets from traces as multiple issue-linked branches and pull requests
+- Active milestone issues: `#18`, `#17`, `#19`
+- Goal: ship offline/manual evals on top of project datasets as multiple issue-linked branches and pull requests
 
 ## Current progress
 
@@ -17,14 +17,14 @@
 - GitHub issue templates, PR template, label sync, and branch protection scripts are added
 - Workspace validation passed with `pnpm lint` and `pnpm test`
 - GitHub labels were synchronized and `main` branch protection was applied
-- Dataset milestone issues are created
-- PR `#14` publishes dataset persistence, shared contracts, backend helpers, and dataset normalization tests
-- PR `#15` publishes project dataset pages, import/export routes, and trace export workflows on top of `#14`
-- PR `#16` publishes repo memory, README/docs copy, demo guidance, and the last dataset coverage updates
-- The full workspace validation currently passes with the stacked dataset branches open
+- Dataset milestone is merged
+- PR `#20` publishes manual eval persistence, shared contracts, backend helpers, and metric helpers
+- PR `#21` publishes manual eval routes, pages, dataset entry points, and the reviewer workspace on top of `#20`
+- The docs and coverage branch updates repo memory, public docs, and reviewer-workspace helper tests
+- Targeted validation passes for Prisma generation, platform linting, platform tests, and shared types builds on the stacked branches
 
 ## Next steps
 
-- Merge `#14`, then retarget `#15` to `main`
-- Merge `#15`, then retarget `#16` to `main`
-- Plan the follow-up issue for offline/manual evals over dataset rows
+- Merge `#20`, retarget `#21` to `main`, then merge `#21`
+- Merge the docs and coverage PR for `#19`
+- Plan the follow-up issue for online evaluators on top of manual eval datasets and rubric history

--- a/.ai/v1-roadmap.md
+++ b/.ai/v1-roadmap.md
@@ -12,16 +12,16 @@
 
 ## Current milestone
 
-- Dataset export from traces
-- Dataset import and export in `json`, `jsonl`, and `csv`
-- Project-scoped dataset browsing in the platform
+- Offline and manual evaluation runs on top of project datasets
+- Project-scoped rubric definitions, run snapshots, and reviewer scoring
+- Platform pages for eval creation, run launch, and row-by-row review
 
-## Near-term next after datasets
+## Near-term next after manual evals
 
-1. Offline and manual evaluation runs
-2. Online evaluators for production traffic
-3. Signals over trace/span and dataset activity
-4. Search, SQL, dashboards, alerts, queues, debugger, and playground
+1. Online evaluators for production traffic
+2. Signals over trace/span, dataset, and eval activity
+3. Search, SQL, dashboards, alerts, queues, debugger, and playground
+4. Eval result exports, annotations, and richer collaboration workflows
 
 ## Ship criteria
 
@@ -29,4 +29,5 @@
 - Platform persists and renders spans
 - Trace pages show debugging-oriented structure instead of only event logs
 - Platform can export traces into append-only datasets and import rows from files
+- Platform can create manual evals from datasets, start runs, and save reviewer scores with pass/fail plus rubric metrics
 - GitHub workflow is documented and automated enough to avoid direct-to-main work

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Captar is designed to provide:
 - Budget reservation and reconciliation before and after model usage
 - Optional export of traces, spend events, and violations to a platform layer
 - Project-scoped datasets built from retained trace payloads
+- Offline/manual eval workflows built from project datasets
 - Minimal integration changes for teams already using OpenAI-based workflows
 
 ## Repository Overview
@@ -134,7 +135,7 @@ The current repository is focused on the first operational slice of Captar:
 - Spend-aware execution and reconciliation
 - Tool tracking and approval hooks
 - Optional export and platform ingestion paths
-- Platform trace debugging plus project-scoped dataset import/export workflows
+- Platform trace debugging, dataset workflows, and manual eval review runs
 - Documentation, demo flows, and platform groundwork
 
 ## Current Platform Workflow
@@ -145,5 +146,7 @@ The current v1 platform flow is:
 2. Inspect them in the platform trace debugger.
 3. Export useful traces into append-only project datasets.
 4. Import or export datasets as `json`, `jsonl`, or `csv`.
+5. Create a manual eval from a dataset and launch reviewer runs.
+6. Score rows with pass/fail plus weighted rubric criteria.
 
-Offline/manual eval execution is the next milestone after the dataset flow. It is not shipped in this repository yet.
+Online evaluators are the next milestone after the manual eval flow. They are not shipped in this repository yet.

--- a/apps/docs/content/quickstart.mdx
+++ b/apps/docs/content/quickstart.mdx
@@ -65,9 +65,10 @@ await captor.flush();
 1. Inspect retained prompts and responses on the trace page.
 2. Export strong traces into a project dataset.
 3. Import or export datasets as `json`, `jsonl`, or `csv`.
-4. Prepare for offline/manual eval runs in the next milestone.
+4. Create a manual eval from the dataset.
+5. Start a run and review rows with pass/fail plus rubric scores.
 
-Dataset export is part of the current v1 platform scope. Eval execution is not shipped yet.
+Manual eval execution is part of the current v1 platform scope. Online evaluators are the next milestone.
 
 ## Event Types
 

--- a/apps/platform/components/manual-eval-run-reviewer.tsx
+++ b/apps/platform/components/manual-eval-run-reviewer.tsx
@@ -5,6 +5,10 @@ import { useEffect, useState, useTransition } from "react";
 
 import type { JsonValue, ManualEval, ManualEvalRun, ManualEvalVerdict } from "@captar/types";
 
+import {
+  calculateManualEvalDraftScore,
+  getNextPendingManualEvalItemId,
+} from "../lib/manual-eval-run-workspace";
 import { Badge } from "./ui/badge";
 import { Button } from "./ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "./ui/card";
@@ -85,7 +89,7 @@ export function ManualEvalRunReviewer({
     .filter((entry): entry is { criterionId: string; score: number } => Boolean(entry));
 
   const canSave = Boolean(verdict) && parsedScores.length === manualEval.criteria.length;
-  const scorePreview = calculateScorePreview(
+  const scorePreview = calculateManualEvalDraftScore(
     manualEval.criteria,
     Object.fromEntries(parsedScores.map((entry) => [entry.criterionId, entry.score])),
   );
@@ -342,17 +346,9 @@ export function ManualEvalRunReviewer({
                   };
                   setRun(payload.run);
                   setMessage("Saved row review.");
-
-                  const refreshedIndex = payload.run.items.findIndex(
-                    (item) => item.id === currentItem.id,
+                  setSelectedItemId(
+                    getNextPendingManualEvalItemId(payload.run.items, currentItem.id),
                   );
-                  const nextPending =
-                    payload.run.items
-                      .slice(refreshedIndex + 1)
-                      .find((item) => !item.verdict) ??
-                    payload.run.items.find((item) => !item.verdict);
-
-                  setSelectedItemId(nextPending?.id ?? currentItem.id);
                 });
               }}
             >
@@ -399,29 +395,4 @@ function PayloadCard({
       </CardContent>
     </Card>
   );
-}
-
-function calculateScorePreview(
-  criteria: ManualEval["criteria"],
-  scores: Record<string, number>,
-) {
-  let weightedTotal = 0;
-  let totalWeight = 0;
-
-  for (const criterion of criteria) {
-    const score = scores[criterion.id];
-
-    if (typeof score !== "number") {
-      continue;
-    }
-
-    weightedTotal += score * criterion.weight;
-    totalWeight += criterion.weight;
-  }
-
-  if (!totalWeight) {
-    return null;
-  }
-
-  return Number((weightedTotal / totalWeight).toFixed(3));
 }

--- a/apps/platform/lib/manual-eval-run-workspace.ts
+++ b/apps/platform/lib/manual-eval-run-workspace.ts
@@ -1,0 +1,39 @@
+import type { ManualEvalCriterion, ManualEvalRunItem } from "@captar/types";
+
+export function calculateManualEvalDraftScore(
+  criteria: ManualEvalCriterion[],
+  scores: Record<string, number>,
+) {
+  let weightedTotal = 0;
+  let totalWeight = 0;
+
+  for (const criterion of criteria) {
+    const score = scores[criterion.id];
+
+    if (typeof score !== "number") {
+      continue;
+    }
+
+    weightedTotal += score * criterion.weight;
+    totalWeight += criterion.weight;
+  }
+
+  if (!totalWeight) {
+    return null;
+  }
+
+  return Number((weightedTotal / totalWeight).toFixed(3));
+}
+
+export function getNextPendingManualEvalItemId(
+  items: ManualEvalRunItem[],
+  currentItemId: string,
+) {
+  const currentIndex = items.findIndex((item) => item.id === currentItemId);
+
+  return (
+    items.slice(Math.max(currentIndex + 1, 0)).find((item) => !item.verdict)?.id ??
+    items.find((item) => !item.verdict)?.id ??
+    currentItemId
+  );
+}

--- a/apps/platform/test/manual-eval-run-workspace.test.ts
+++ b/apps/platform/test/manual-eval-run-workspace.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  calculateManualEvalDraftScore,
+  getNextPendingManualEvalItemId,
+} from "../lib/manual-eval-run-workspace";
+
+const criteria = [
+  {
+    id: "accuracy",
+    position: 1,
+    label: "Accuracy",
+    weight: 2,
+  },
+  {
+    id: "grounding",
+    position: 2,
+    label: "Grounding",
+    weight: 1,
+  },
+] as const;
+
+describe("manual eval run workspace helpers", () => {
+  it("calculates the weighted draft score preview", () => {
+    expect(
+      calculateManualEvalDraftScore([...criteria], {
+        accuracy: 4,
+        grounding: 5,
+      }),
+    ).toBe(4.333);
+  });
+
+  it("returns null when no scores are present", () => {
+    expect(calculateManualEvalDraftScore([...criteria], {})).toBeNull();
+  });
+
+  it("prefers the next pending row after the current selection", () => {
+    expect(
+      getNextPendingManualEvalItemId(
+        [
+          { id: "row-1", verdict: "pass" },
+          { id: "row-2" },
+          { id: "row-3" },
+        ] as never,
+        "row-1",
+      ),
+    ).toBe("row-2");
+  });
+
+  it("falls back to the current row when every row is reviewed", () => {
+    expect(
+      getNextPendingManualEvalItemId(
+        [
+          { id: "row-1", verdict: "pass" },
+          { id: "row-2", verdict: "fail" },
+        ] as never,
+        "row-2",
+      ),
+    ).toBe("row-2");
+  });
+});


### PR DESCRIPTION
## Linked Issue

- Closes #19

## Summary

- update `.ai/` repo memory plus README and quickstart docs for the new trace -> dataset -> manual eval flow
- factor reviewer-workspace draft score and pending-row selection into a pure helper
- add helper coverage for manual eval run workspace behavior on top of the stacked platform PR

## Validation

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] Additional validation noted below

Additional validation:
- [x] `pnpm db:generate`

## Risk and Rollback

- Risk level: Low, because this is documentation, repo memory, and test-focused follow-up work on top of the stacked feature PRs.
- Rollback plan: Revert this branch before merge or revert the merge commit after the feature branches land.

## Screenshots

- [ ] UI change with screenshots attached
- [x] No UI change
