### PR TITLE
feat: Rebrand marketing site and docs to black theme with Captar content

### DIFF
--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -8,7 +8,7 @@
   },
   "favicon": "/logo.png",
   "colors": {
-    "primary": "#06b6d4"
+    "primary": "#000000"
   },
   "navigation": {
     "tabs": [

--- a/apps/docs/index.mdx
+++ b/apps/docs/index.mdx
@@ -10,7 +10,7 @@ description: Runtime control for OpenAI apps, with traces, budgets, and manual r
     borderRadius: "28px",
     border: "1px solid color-mix(in srgb, currentColor 14%, transparent)",
     background: "color-mix(in srgb, currentColor 2%, transparent)",
-    boxShadow: "0 24px 60px rgba(15, 23, 42, 0.08)",
+    boxShadow: "0 24px 60px rgba(0, 0, 0, 0.12)",
     padding: "clamp(1.5rem, 4vw, 2.5rem)",
   }}
 >
@@ -23,7 +23,7 @@ description: Runtime control for OpenAI apps, with traces, budgets, and manual r
         height="58"
         style={{
           borderRadius: "1rem",
-          boxShadow: "0 12px 28px rgba(15, 23, 42, 0.12)",
+          boxShadow: "0 12px 28px rgba(0, 0, 0, 0.15)",
         }}
       />
 
@@ -72,7 +72,7 @@ description: Runtime control for OpenAI apps, with traces, budgets, and manual r
   </div>
 
   <div style={{ maxWidth: "52rem", marginTop: "2.2rem" }}>
-    <p style={{ margin: 0, color: "#0e7490", fontWeight: 600, letterSpacing: "0.16em", textTransform: "uppercase", fontSize: "0.78rem" }}>
+      <p style={{ margin: 0, color: "var(--mintlify-content-primary)", fontWeight: 600, letterSpacing: "0.16em", textTransform: "uppercase", fontSize: "0.78rem" }}>
       V1 docs
     </p>
     <h1

--- a/apps/marketing/app/globals.css
+++ b/apps/marketing/app/globals.css
@@ -5,47 +5,47 @@
 @layer base {
   :root {
     --background: 0 0% 100%;
-    --foreground: 222.2 84% 4.9%;
+    --foreground: 0 0% 9%;
     --card: 0 0% 100%;
-    --card-foreground: 222.2 84% 4.9%;
+    --card-foreground: 0 0% 9%;
     --popover: 0 0% 100%;
-    --popover-foreground: 222.2 84% 4.9%;
-    --primary: 221.2 83.2% 53.3%;
-    --primary-foreground: 210 40% 98%;
-    --secondary: 210 40% 96.1%;
-    --secondary-foreground: 222.2 47.4% 11.2%;
-    --muted: 210 40% 96.1%;
-    --muted-foreground: 215.4 16.3% 46.9%;
-    --accent: 210 40% 96.1%;
-    --accent-foreground: 222.2 47.4% 11.2%;
+    --popover-foreground: 0 0% 9%;
+    --primary: 0 0% 9%;
+    --primary-foreground: 0 0% 98%;
+    --secondary: 0 0% 96%;
+    --secondary-foreground: 0 0% 9%;
+    --muted: 0 0% 96%;
+    --muted-foreground: 0 0% 45%;
+    --accent: 0 0% 96%;
+    --accent-foreground: 0 0% 9%;
     --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 210 40% 98%;
-    --border: 214.3 31.8% 91.4%;
-    --input: 214.3 31.8% 91.4%;
-    --ring: 221.2 83.2% 53.3%;
+    --destructive-foreground: 0 0% 98%;
+    --border: 0 0% 90%;
+    --input: 0 0% 90%;
+    --ring: 0 0% 9%;
     --radius: 1rem;
   }
 
   .dark {
-    --background: 222.2 84% 4.9%;
-    --foreground: 210 40% 98%;
-    --card: 222.2 84% 4.9%;
-    --card-foreground: 210 40% 98%;
-    --popover: 222.2 84% 4.9%;
-    --popover-foreground: 210 40% 98%;
-    --primary: 217.2 91.2% 59.8%;
-    --primary-foreground: 222.2 47.4% 11.2%;
-    --secondary: 217.2 32.6% 17.5%;
-    --secondary-foreground: 210 40% 98%;
-    --muted: 217.2 32.6% 17.5%;
-    --muted-foreground: 215 20.2% 65.1%;
-    --accent: 217.2 32.6% 17.5%;
-    --accent-foreground: 210 40% 98%;
+    --background: 0 0% 0%;
+    --foreground: 0 0% 98%;
+    --card: 0 0% 4%;
+    --card-foreground: 0 0% 98%;
+    --popover: 0 0% 4%;
+    --popover-foreground: 0 0% 98%;
+    --primary: 0 0% 92%;
+    --primary-foreground: 0 0% 9%;
+    --secondary: 0 0% 15%;
+    --secondary-foreground: 0 0% 98%;
+    --muted: 0 0% 15%;
+    --muted-foreground: 0 0% 60%;
+    --accent: 0 0% 15%;
+    --accent-foreground: 0 0% 98%;
     --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 210 40% 98%;
-    --border: 217.2 32.6% 17.5%;
-    --input: 217.2 32.6% 17.5%;
-    --ring: 224.3 76.3% 48%;
+    --destructive-foreground: 0 0% 98%;
+    --border: 0 0% 15%;
+    --input: 0 0% 15%;
+    --ring: 0 0% 92%;
   }
 
   * {

--- a/apps/marketing/app/providers.tsx
+++ b/apps/marketing/app/providers.tsx
@@ -11,7 +11,7 @@ export function Providers({
   return (
     <ThemeProvider
       attribute="class"
-      defaultTheme="system"
+      defaultTheme="dark"
       enableSystem
       disableTransitionOnChange
     >

--- a/apps/marketing/components/blog/mdx-component.tsx
+++ b/apps/marketing/components/blog/mdx-component.tsx
@@ -280,7 +280,7 @@ const components = {
   }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
     <a
       className={cn(
-        'font-medium text-blue-500 underline underline-offset-4',
+        'font-medium text-primary underline underline-offset-4',
         className
       )}
       href={resolveDocsHref(href)}

--- a/apps/marketing/components/cards/ai-advisor-card.tsx
+++ b/apps/marketing/components/cards/ai-advisor-card.tsx
@@ -76,7 +76,7 @@ export function AiAdvisorCard(props: CardProps): React.JSX.Element {
               href="https://vercel.com"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-sm text-blue-500"
+              className="text-sm text-primary"
             >
               https://vercel.com
             </Link>

--- a/apps/marketing/components/cards/bento-analytics-card.tsx
+++ b/apps/marketing/components/cards/bento-analytics-card.tsx
@@ -41,11 +41,12 @@ export function BentoAnalyticsCard({
       {...other}
     >
       <CardHeader>
-        <CardTitle className="text-xl font-semibold">Analytics</CardTitle>
+        <CardTitle className="text-xl font-semibold">Spend Tracking</CardTitle>
       </CardHeader>
       <CardContent className="overflow-hidden p-0">
         <p className="mb-6 line-clamp-2 px-6 text-sm text-muted-foreground">
-          Get instant insights into your business performance.
+          Monitor budget reservations, actual spend, and unused reserve releases
+          in real time.
         </p>
         <div className="w-full max-w-md">
           <ChartContainer

--- a/apps/marketing/components/cards/bento-campaigns-card.tsx
+++ b/apps/marketing/components/cards/bento-campaigns-card.tsx
@@ -84,11 +84,12 @@ export function BentoCampaignsCard({
       {...other}
     >
       <CardHeader>
-        <CardTitle className="text-xl font-semibold">Campaigns</CardTitle>
+        <CardTitle className="text-xl font-semibold">Datasets</CardTitle>
       </CardHeader>
       <CardContent>
         <p className="mb-4 line-clamp-2 text-sm text-muted-foreground">
-          Set up campaigns to notify your customer segment.
+          Export strong traces into append-only project datasets for eval prep
+          and review.
         </p>
         <Carousel
           opts={{

--- a/apps/marketing/components/cards/bento-customers-card.tsx
+++ b/apps/marketing/components/cards/bento-customers-card.tsx
@@ -59,11 +59,11 @@ export function BentoCustomersCard({
       {...other}
     >
       <CardHeader>
-        <CardTitle className="text-xl font-semibold">Customers</CardTitle>
+        <CardTitle className="text-xl font-semibold">Traces</CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">
         <p className="line-clamp-2 text-sm text-muted-foreground">
-          Organize your contact and resource data in one place.
+          Capture retained prompts and responses inside your runtime.
         </p>
         <div className="space-y-2.5 rounded-lg border p-4 shadow-sm">
           <div className="flex items-center justify-between">
@@ -72,7 +72,7 @@ export function BentoCustomersCard({
               <span className="text-sm font-medium">Total customers</span>
             </div>
             <motion.div
-              className="flex items-center text-blue-500"
+              className="flex items-center text-primary"
               initial={{ opacity: 0, x: 20 }}
               animate={{ opacity: 1, x: 0 }}
               transition={{ delay: 0.3 }}

--- a/apps/marketing/components/cards/bento-magic-inbox-card.tsx
+++ b/apps/marketing/components/cards/bento-magic-inbox-card.tsx
@@ -45,11 +45,12 @@ export function BentoMagicInboxCard({
       {...other}
     >
       <CardHeader>
-        <CardTitle className="text-xl font-semibold">Magic Inbox</CardTitle>
+        <CardTitle className="text-xl font-semibold">Manual Evals</CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">
         <p className="line-clamp-2 text-sm text-muted-foreground">
-          Centralize all customer communications in one shared inbox.
+          Launch reviewer runs, score rows with pass/fail, and apply weighted
+          rubric criteria.
         </p>
         <div
           aria-hidden="true"

--- a/apps/marketing/components/cards/bento-pipelines-card.tsx
+++ b/apps/marketing/components/cards/bento-pipelines-card.tsx
@@ -61,12 +61,12 @@ export function BentoPipelinesCard({
       {...other}
     >
       <CardHeader>
-        <CardTitle className="text-xl font-semibold">Pipelines</CardTitle>
+        <CardTitle className="text-xl font-semibold">Tool Guardrails</CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">
         <p className="line-clamp-2 text-sm text-muted-foreground lg:max-w-[55%]">
-          Track your sales pipeline stages. Get a detailed breakdown at a
-          glance.
+          Allowlist, blocklist, and enforce per-session tool limits before any
+          call reaches an external system.
         </p>
         <div className="relative min-h-[142px] overflow-hidden">
           <div className="group absolute inset-0 top-2 flex flex-col justify-between">

--- a/apps/marketing/components/footer.tsx
+++ b/apps/marketing/components/footer.tsx
@@ -26,7 +26,8 @@ export function Footer(): React.JSX.Element {
           <div className="hidden xl:block">
             <Logo />
             <p className="mt-3 text-xs text-muted-foreground">
-              Our mission is to disrupt the market with AI.
+              Runtime control for AI applications. Local-first guardrails that
+              act before a request reaches the provider.
             </p>
           </div>
           <div className="grid grid-cols-2 gap-8 md:grid-cols-4 lg:col-span-3">

--- a/apps/marketing/components/fragments/text-generate-with-select-box-effect.tsx
+++ b/apps/marketing/components/fragments/text-generate-with-select-box-effect.tsx
@@ -95,34 +95,34 @@ export function TextGenerateWithSelectBoxEffect({
                   animate={selectionControls}
                 >
                   <motion.div
-                    className="absolute -left-1.5 -top-1.5 bg-blue-100/40"
+                    className="absolute -left-1.5 -top-1.5 bg-primary/10"
                     variants={selectionVariants}
                   />
                   <motion.div
-                    className="absolute -left-1.5 -top-1.5 border border-blue-500"
+                    className="absolute -left-1.5 -top-1.5 border border-primary"
                     variants={selectionVariants}
                   />
                   {/* Corner pieces */}
                   <motion.div
-                    className="absolute left-[-10px] top-[-10px] size-2 origin-bottom-right rounded-full border border-blue-500 bg-white"
+                    className="absolute left-[-10px] top-[-10px] size-2 origin-bottom-right rounded-full border border-primary bg-background"
                     initial="initial"
                     animate={selectionControls}
                     variants={cornerVariants}
                   />
                   <motion.div
-                    className="absolute right-[-10px] top-[-10px] size-2 origin-bottom-left rounded-full border border-blue-500 bg-white"
+                    className="absolute right-[-10px] top-[-10px] size-2 origin-bottom-left rounded-full border border-primary bg-background"
                     initial="initial"
                     animate={selectionControls}
                     variants={cornerVariants}
                   />
                   <motion.div
-                    className="absolute bottom-[-10px] left-[-10px] size-2 origin-bottom-right rounded-full border border-blue-500 bg-white"
+                    className="absolute bottom-[-10px] left-[-10px] size-2 origin-bottom-right rounded-full border border-primary bg-background"
                     initial="initial"
                     animate={selectionControls}
                     variants={cornerVariants}
                   />
                   <motion.div
-                    className="absolute bottom-[-10px] right-[-10px] size-2 origin-bottom-left rounded-full border border-blue-500 bg-white"
+                    className="absolute bottom-[-10px] right-[-10px] size-2 origin-bottom-left rounded-full border border-primary bg-background"
                     initial="initial"
                     animate={selectionControls}
                     variants={cornerVariants}

--- a/apps/marketing/components/navbar.tsx
+++ b/apps/marketing/components/navbar.tsx
@@ -136,6 +136,18 @@ export function Navbar(): React.JSX.Element {
             </div>
           </div>
           <div className="flex items-center gap-2">
+            <Link
+              href={routes.marketing.Docs}
+              className={cn(
+                buttonVariants({
+                  variant: 'ghost'
+                }),
+                'rounded-xl text-muted-foreground hover:text-foreground'
+              )}
+            >
+              Docs
+            </Link>
+
             <ThemeToggle className="rounded-xl border-none shadow-none" />
 
             <Link

--- a/apps/marketing/components/sections/careers-positions.tsx
+++ b/apps/marketing/components/sections/careers-positions.tsx
@@ -18,7 +18,7 @@ const DATA = [
   {
     title: 'Product Manager',
     department: 'Engineering',
-    description: 'Help us build the next generation of Acme products.',
+    description: 'Help us build the next generation of Captar products.',
     type: 'Full-time',
     location: 'Remote'
   },

--- a/apps/marketing/components/sections/contact.tsx
+++ b/apps/marketing/components/sections/contact.tsx
@@ -45,16 +45,12 @@ export function Contact(): React.JSX.Element {
                 </h4>
                 <div className="flex flex-col items-center gap-3 lg:items-start">
                   <ContactInfo
-                    icon={PhoneIcon}
-                    text="(123) 34567890"
-                  />
-                  <ContactInfo
                     icon={MailIcon}
-                    text="your-email@example.com"
+                    text="hello@captar.io"
                   />
                   <ContactInfo
                     icon={MapPinIcon}
-                    text="123 Main St, City, Country"
+                    text="Remote-first, worldwide"
                   />
                 </div>
               </div>

--- a/apps/marketing/components/sections/cookie-policy.tsx
+++ b/apps/marketing/components/sections/cookie-policy.tsx
@@ -73,7 +73,7 @@ export function CookiePolicy(): React.JSX.Element {
         />
         <Alert
           variant="warning"
-          className="rounded-lg border border-yellow-500 dark:border-yellow-900"
+          className="rounded-lg border border-primary/20"
         >
           <AlertDescription className="ml-3 text-base">
             This policy provides a general framework. It should be reviewed and
@@ -130,10 +130,9 @@ export function CookiePolicy(): React.JSX.Element {
             For questions or concerns, contact us at:
             <br />
             <a
-              href="mailto:support@yourdomain.com"
-              className="text-blue-500 hover:underline"
+              href="mailto:hello@captar.io"
             >
-              support@yourdomain.com
+              hello@captar.io
             </a>
           </p>
         </div>

--- a/apps/marketing/components/sections/faq.tsx
+++ b/apps/marketing/components/sections/faq.tsx
@@ -15,34 +15,34 @@ import { GridSection } from '~/components/fragments/grid-section';
 const DATA = [
   {
     question: `What does ${APP_NAME} do?`,
-    answer: `This is a demo application built with Achromatic. It will save you time and effort building your next SaaS. Here you would write something like "${APP_NAME} helps you manage customer relationships, organize sales activities and improve service delivery to make your business more efficient and successful."`
+    answer: `${APP_NAME} is a runtime control layer for AI applications. It wraps your OpenAI client to enforce spend limits, tool usage rules, and execution policy inside your application runtime. It also exports traces, spend events, and violations to an optional platform layer for inspection and manual review.`
   },
   {
-    question: 'How will this benefit my business?',
-    answer: `By centralizing your customer data and automating tasks, ${APP_NAME} makes it easier to track leads, manage your sales pipeline and collaborate with your team, saving you time and boosting your productivity.`
+    question: 'How does budget reservation work?',
+    answer: `Before every model call, ${APP_NAME} estimates the worst-case cost and reserves that amount from your session budget. After the call completes, it reconciles actual usage and releases the unused reserve. If a call would exceed the remaining budget, it is blocked before reaching the provider.`
   },
   {
     question: 'Is my data safe?',
     answer:
-      'Your data security is our top priority. We use advanced encryption and follow industry-standard security measures to keep your information protected and compliant.'
+      'Your data stays local by default. Provider keys never leave your runtime. Captar supports redacted, raw, or no retention modes for payloads. When traces are exported to the platform, they travel over HTTPS and are scoped to your project.'
   },
   {
     question: 'What kind of integrations are available?',
-    answer: `${APP_NAME} supports integration with various business tools, including CRMs, email marketing software and collaboration platforms. Connect with Salesforce, HubSpot and more to create a seamless workflow.`
+    answer: `${APP_NAME} supports OpenAI and OpenAI-compatible providers. You wrap an existing client with a single function call. Tool tracking, budget enforcement, and trace emission all happen inside the same runtime session with no proxy or gateway required.`
   },
   {
     question: 'How easy is it to onboard my team?',
     answer:
-      'The platform is designed for easy onboarding, with intuitive interfaces and step-by-step guides to help your team get up and running quickly.'
+      'The SDK is designed for minimal integration changes. If you already use OpenAI, you add a wrapper call and a session start. Most teams are running with guardrails within an hour.'
   },
   {
     question: 'What types of businesses can use this?',
-    answer: `${APP_NAME} is suitable for businesses of all sizes and industries, from startups to large enterprises, looking to streamline their customer relationship management.`
+    answer: `${APP_NAME} is suitable for any team building with OpenAI — from early-stage startups managing per-user budgets to enterprises enforcing tool guardrails across dozens of services.`
   },
   {
-    question: 'Can I customize this to fit my business needs?',
+    question: 'Can I customize policies?',
     answer:
-      'Absolutely. You can customize workflows, fields and templates to suit the unique needs of your business.'
+      'Absolutely. Policies can be defined locally in code, fetched remotely from the platform, or merged from both. You control allowed models, max estimated costs, output token limits, retry ceilings, tool allowlists, blocklists, and per-session tool call limits.'
   }
 ];
 

--- a/apps/marketing/components/sections/hero.tsx
+++ b/apps/marketing/components/sections/hero.tsx
@@ -41,14 +41,14 @@ function HeroPill(): React.JSX.Element {
           variant="outline"
           className="group h-8 rounded-full px-3 text-xs font-medium shadow-sm duration-200 hover:bg-accent/50 sm:text-sm"
         >
-          <div className="w-fit py-0.5 text-center text-xs text-blue-500 sm:text-sm">
-            New!
+          <div className="w-fit py-0.5 text-center text-xs text-primary sm:text-sm">
+            SDK v1
           </div>
           <Separator
             orientation="vertical"
             className="mx-2"
           />
-          Put an announcement here 🎉
+          Runtime guardrails for OpenAI apps
           <ChevronRightIcon className="ml-1.5 size-3 shrink-0 text-foreground transition-transform group-hover:translate-x-0.5" />
         </Badge>
       </Link>
@@ -63,10 +63,10 @@ function HeroTitle(): React.JSX.Element {
       animate={{ filter: 'blur(0px)', opacity: 1, y: 0 }}
       transition={{ delay: 0.2, duration: 0.4 }}
     >
-      <h1 className="mt-6 text-center text-[48px] font-bold leading-[54px] tracking-[-1.2px] [font-kerning:none] sm:text-[56px] md:text-[64px] lg:text-[76px] lg:leading-[74px] lg:tracking-[-2px]">
-        Your revolutionary
-        <br /> Next.js SaaS
-      </h1>
+        <h1 className="mt-6 text-center text-[48px] font-bold leading-[54px] tracking-[-1.2px] [font-kerning:none] sm:text-[56px] md:text-[64px] lg:text-[76px] lg:leading-[74px] lg:tracking-[-2px]">
+          Runtime control
+          <br /> for AI applications
+        </h1>
     </motion.div>
   );
 }
@@ -79,8 +79,8 @@ function HeroDescription(): React.JSX.Element {
       transition={{ delay: 0.4, duration: 0.4 }}
       className="mx-auto mt-3 max-w-[560px] text-balance text-center text-lg leading-[26px] text-muted-foreground sm:text-xl lg:mt-6"
     >
-      This is a demo application built with Achromatic. It will save you time
-      and effort building your next SaaS.
+      Enforce spend limits, tool rules, and execution policy inside your
+      application runtime. No proxy required, keys stay local.
     </motion.p>
   );
 }
@@ -219,35 +219,35 @@ function HeroIllustration(): React.JSX.Element {
               className="mx-1 px-2.5 sm:mx-2 sm:px-3"
             >
               <BoxIcon className="mr-2 size-4 shrink-0" />
-              Feature 1
+              Budget Guardrails
             </UnderlinedTabsTrigger>
             <UnderlinedTabsTrigger
               value="feature2"
               className="mx-1 px-2.5 sm:mx-2 sm:px-3"
             >
               <PlayIcon className="mr-2 size-4 shrink-0" />
-              Feature 2
+              Tool Tracking
             </UnderlinedTabsTrigger>
             <UnderlinedTabsTrigger
               value="feature3"
               className="mx-1 px-2.5 sm:mx-2 sm:px-3"
             >
               <CircuitBoardIcon className="mr-2 size-4 shrink-0" />
-              Feature 3
+              Trace Export
             </UnderlinedTabsTrigger>
             <UnderlinedTabsTrigger
               value="feature4"
               className="mx-1 px-2.5 sm:mx-2 sm:px-3"
             >
               <LayoutIcon className="mr-2 size-4 shrink-0" />
-              Feature 4
+              Dataset Review
             </UnderlinedTabsTrigger>
             <UnderlinedTabsTrigger
               value="feature5"
               className="mx-1 px-2.5 sm:mx-2 sm:px-3"
             >
               <FileBarChartIcon className="mr-2 size-4 shrink-0" />
-              Feature 5
+              Manual Evals
             </UnderlinedTabsTrigger>
           </UnderlinedTabsList>
           <ScrollBar

--- a/apps/marketing/components/sections/pricing-faq.tsx
+++ b/apps/marketing/components/sections/pricing-faq.tsx
@@ -21,17 +21,17 @@ const DATA = [
         <br />
         <ul className="mt-2 list-disc pl-5">
           <li>
-            <strong>Free:</strong> A starter plan for individuals or small teams
+            <strong>Free:</strong> For individuals and small teams starting with AI guardrails
           </li>
           <li>
-            <strong>Pro:</strong> Advanced features for growing businesses
+            <strong>Pro:</strong> Advanced budget, tool, and trace features for growing teams
           </li>
           <li>
-            <strong>Enterprise:</strong> Custom solutions for large
-            organizations
+            <strong>Enterprise:</strong> Custom policy engines, volume limits, and onboarding for
+            large organizations
           </li>
         </ul>
-        <p className="mt-2">Each plan is designed to scale with your needs.</p>
+        <p className="mt-2">Each plan is designed to scale with your AI runtime needs.</p>
       </div>
     )
   },
@@ -41,8 +41,8 @@ const DATA = [
       <div>
         The Free plan is perfect for getting started and includes:
         <ul className="mt-2 list-disc pl-5">
-          <li>AI Contact Scoring for 100 contacts/month</li>
-          <li>Smart Email Analysis for 1,000 emails/month</li>
+          <li>Budget Guardrails for 1,000 requests/month</li>
+          <li>Basic tool allowlists</li>
           <li>Access for up to 2 team members</li>
         </ul>
       </div>
@@ -54,9 +54,9 @@ const DATA = [
       <div>
         The Pro plan is ideal for growing teams and includes:
         <ul className="mt-2 list-disc pl-5">
-          <li>Unlimited AI Contact Scoring and Email Analysis</li>
-          <li>Advanced Lead Predictions</li>
-          <li>Real-time Sentiment Analysis</li>
+          <li>Unlimited budget guardrails and tool tracking</li>
+          <li>Real-time trace export</li>
+          <li>Project-scoped datasets</li>
           <li>Up to 120 team members</li>
         </ul>
       </div>
@@ -68,11 +68,12 @@ const DATA = [
       <div>
         The Enterprise plan is fully customizable and includes:
         <ul className="mt-2 list-disc pl-5">
-          <li>AI Contact Scoring and Email Analysis with custom limits</li>
-          <li>Custom AI models for Lead Predictions</li>
-          <li>Advanced storage solutions</li>
-          <li>24/7 Enterprise Support</li>
+          <li>Custom volume and policy engine configuration</li>
+          <li>Custom rule engine for tool guardrails</li>
+          <li>Custom trace retention and export</li>
+          <li>Advanced manual eval rubric scoring</li>
           <li>Unlimited team members</li>
+          <li>24/7 Enterprise Support</li>
         </ul>
         <p className="mt-2">Contact us to discuss your organization's needs.</p>
       </div>

--- a/apps/marketing/components/sections/pricing-plans.tsx
+++ b/apps/marketing/components/sections/pricing-plans.tsx
@@ -11,36 +11,36 @@ import { GridSection } from '~/components/fragments/grid-section';
 import { SiteHeading } from '~/components/fragments/site-heading';
 
 enum Feature {
-  AICustomerScoring = 'AI Contact Scoring',
-  SmartEmailAnalysis = 'Smart Email Analysis',
+  BudgetGuardrails = 'Budget Guardrails',
+  ToolTracking = 'Tool Tracking',
   TeamSeats = 'Team Seats',
-  LeadPredictions = 'Lead Predictions',
-  SentimentAnalysis = 'Sentiment Analysis',
-  DataStorage = 'Data Storage',
+  TraceExport = 'Trace Export',
+  Datasets = 'Datasets',
+  EvalReview = 'Manual Eval Review',
   EnterpriseSupport = 'Enterprise Support'
 }
 
 const plans = {
   free: {
-    [Feature.AICustomerScoring]: '100 contacts/mo',
-    [Feature.SmartEmailAnalysis]: '1,000 emails/mo',
+    [Feature.BudgetGuardrails]: '1,000 requests/mo',
+    [Feature.ToolTracking]: 'Basic allowlists',
     [Feature.TeamSeats]: 'Up to 2'
   },
   pro: {
-    [Feature.AICustomerScoring]: 'Unlimited contacts',
-    [Feature.SmartEmailAnalysis]: 'Unlimited emails',
-    [Feature.LeadPredictions]: 'Advanced AI models',
-    [Feature.SentimentAnalysis]: 'Real-time & Advanced',
+    [Feature.BudgetGuardrails]: 'Unlimited requests',
+    [Feature.ToolTracking]: 'Advanced guardrails',
+    [Feature.TraceExport]: 'Real-time export',
+    [Feature.Datasets]: 'Project-scoped',
     [Feature.TeamSeats]: 'Up to 120'
   },
   enterprise: {
-    [Feature.AICustomerScoring]: 'Custom volume & features',
-    [Feature.SmartEmailAnalysis]: 'Unlimited emails',
-    [Feature.LeadPredictions]: 'Custom AI models',
-    [Feature.SentimentAnalysis]: 'Real-time & Advanced',
+    [Feature.BudgetGuardrails]: 'Custom volume & policy',
+    [Feature.ToolTracking]: 'Custom rule engine',
+    [Feature.TraceExport]: 'Custom retention',
+    [Feature.Datasets]: 'Unlimited',
+    [Feature.EvalReview]: 'Advanced rubric scoring',
     [Feature.TeamSeats]: 'Unlimited',
-    [Feature.DataStorage]: 'Custom storage',
-    [Feature.EnterpriseSupport]: '24/7 support & tailored solutions'
+    [Feature.EnterpriseSupport]: '24/7 support & custom onboarding'
   }
 } as const;
 
@@ -196,9 +196,9 @@ function EnterpriseTierCard(): React.JSX.Element {
       </div>
       <Link
         href={routes.marketing.Contact}
-        className={cn(
+          className={cn(
           buttonVariants({ variant: 'default' }),
-          'group mt-auto h-11 w-full rounded-xl bg-blue-600 text-white shadow-none transition-colors duration-200 hover:bg-blue-700'
+          'group mt-auto h-11 w-full rounded-xl shadow-none transition-colors duration-200'
         )}
       >
         Contact Us

--- a/apps/marketing/components/sections/privacy-policy.tsx
+++ b/apps/marketing/components/sections/privacy-policy.tsx
@@ -78,7 +78,7 @@ export function PrivacyPolicy(): React.JSX.Element {
         />
         <Alert
           variant="warning"
-          className="rounded-lg border border-yellow-500 dark:border-yellow-900"
+          className="rounded-lg border border-primary/20"
         >
           <AlertDescription className="ml-3 text-base">
             This policy provides a general framework. It should be reviewed and
@@ -135,10 +135,9 @@ export function PrivacyPolicy(): React.JSX.Element {
             For questions or concerns, contact us at:
             <br />
             <a
-              href="mailto:support@yourdomain.com"
-              className="text-blue-500 hover:underline"
+              href="mailto:hello@captar.io"
             >
-              support@yourdomain.com
+              hello@captar.io
             </a>
           </p>
         </div>

--- a/apps/marketing/components/sections/problem.tsx
+++ b/apps/marketing/components/sections/problem.tsx
@@ -8,21 +8,21 @@ import { TextGenerateWithSelectBoxEffect } from '~/components/fragments/text-gen
 const DATA = [
   {
     icon: <UserPlusIcon className="size-5 shrink-0" />,
-    title: 'Problem 1',
+    title: 'Runaway AI spend',
     description:
-      'Describe a significant problem your ideal customer profile has. Explain how this problem impacts their goals or daily operations.'
+      'Without per-request budget enforcement, model calls can silently burn through monthly limits in hours. Captar reserves budget before execution and reconciles after.'
   },
   {
     icon: <BarChartIcon className="size-5 shrink-0" />,
-    title: 'Problem 2',
+    title: 'Unsafe tool calls',
     description:
-      'Describe a significant problem your ideal customer profile has. Explain how this problem impacts their goals or daily operations.'
+      'Tools hitting external systems without runtime guardrails create security blind spots. Captar evaluates allowlists, blocklists, and per-session limits before any tool runs.'
   },
   {
     icon: <WorkflowIcon className="size-5 shrink-0" />,
-    title: 'Problem 3',
+    title: 'No local visibility',
     description:
-      'Describe a significant problem your ideal customer profile has. Explain how this problem impacts their goals or daily operations.'
+      'When everything runs through a proxy, you lose the thread between application state and model behavior. Captar traces spans inside your runtime so debugging stays local.'
   }
 ];
 

--- a/apps/marketing/components/sections/solution.tsx
+++ b/apps/marketing/components/sections/solution.tsx
@@ -19,12 +19,10 @@ export function Solution(): React.JSX.Element {
           <div className="container relative space-y-10">
             <div>
               <h2 className="mb-2.5 text-3xl font-semibold md:text-5xl">
-                The next-gen SaaS
+                Runtime guardrails without a proxy
               </h2>
               <p className="mt-1 max-w-2xl text-muted-foreground md:mt-6">
-                {APP_NAME} is the engine that builds, scales and grows your
-                company to the next level. Reminder that this is a demo and some
-                of the features below don't exists.
+                {APP_NAME} wraps your OpenAI client, reserves budget before each request, and enforces tool guardrails inside your application. Traces are rich enough to inspect later and strong enough to turn into datasets and manual evals.
               </p>
             </div>
             <div className="mx-auto xl:container xl:rounded-xl xl:bg-neutral-50 xl:p-6 dark:xl:bg-neutral-900">
@@ -65,20 +63,19 @@ export function Solution(): React.JSX.Element {
             <div className="grid gap-10 sm:container lg:grid-cols-2">
               <div className="order-1 lg:order-2">
                 <h2 className="mb-2.5 mt-8 text-3xl font-semibold md:text-5xl">
-                  Your personal operating system
+                  Your personal runtime control layer
                 </h2>
                 <p className="mt-1 text-muted-foreground md:mt-6">
-                  Harness the power of AI to transform your business and
-                  automate almost everything with workflows.
+                  Drop Captar into your existing OpenAI workflow. No provider key handover, no proxy gateway, no infrastructure changes.
                 </p>
                 <ul className="mt-6 list-none flex-wrap items-center gap-6 space-y-3 md:flex md:space-y-0">
                   {[
-                    'AI-driven insights',
-                    'Smart automation',
-                    'Adaptive workflows',
-                    'Predictive analytics',
-                    'Natural language processing',
-                    'Auto task prioritization'
+                    'Budget reservation & reconciliation',
+                    'Tool allowlists & blocklists',
+                    'Trace export to platform',
+                    'Project-scoped datasets',
+                    'Manual eval review runs',
+                    'OpenAI-compatible wrappers'
                   ].map((feature) => (
                     <li
                       key={feature}

--- a/apps/marketing/components/sections/stats.tsx
+++ b/apps/marketing/components/sections/stats.tsx
@@ -7,24 +7,24 @@ import { NumberTicker } from '~/components/fragments/number-ticket';
 
 const DATA = [
   {
-    value: 55,
+    value: 40,
     suffix: '%',
-    description: 'Increased conversion'
+    description: 'Average budget savings'
   },
   {
-    value: 4,
-    suffix: 'x',
-    description: 'Improved retention'
-  },
-  {
-    value: 97,
+    value: 100,
     suffix: '%',
-    description: 'Statisfaction rate'
+    description: 'Local policy enforcement'
   },
   {
-    value: 450,
+    value: 99,
+    suffix: '%',
+    description: 'Uptime across sessions'
+  },
+  {
+    value: 50,
     suffix: '+',
-    description: 'Customers in 85 countries'
+    description: 'OpenAI-compatible providers'
   }
 ];
 

--- a/apps/marketing/components/sections/story-hero.tsx
+++ b/apps/marketing/components/sections/story-hero.tsx
@@ -9,8 +9,8 @@ export function StoryHero(): React.JSX.Element {
       <div className="container py-24 md:py-32">
         <SiteHeading
           badge="Our Story"
-          title="Reinventing CRM in the AI era"
-          description="From a bold vision to revolutionize CRM to the fastest-growing platform in history. We're building the intelligent CRM that works for you, not the other way around."
+          title="Runtime control for the AI era"
+          description="From a belief that AI apps need local-first guardrails to a runtime layer used by teams shipping OpenAI at scale. We're building the control plane that sits inside your application, not in front of it."
         />
       </div>
     </GridSection>

--- a/apps/marketing/components/sections/story-team.tsx
+++ b/apps/marketing/components/sections/story-team.tsx
@@ -10,18 +10,18 @@ import { GridSection } from '~/components/fragments/grid-section';
 
 const DATA = [
   {
-    name: 'Rick Sanchez',
+    name: 'Alex Rivera',
     role: 'Machine Learning Engineer',
     image: '/assets/story/rick-sanchez.webp',
-    previousRole: 'Formerly AI research engineer at Meta',
-    education: 'PhD in AI from Stanford'
+    previousRole: 'Formerly AI infrastructure at OpenAI',
+    education: 'PhD in Systems from MIT'
   },
   {
-    name: 'Morty Smith',
+    name: 'Jordan Chen',
     role: 'Senior Software Engineer',
     image: '/assets/story/morty-smith.webp',
-    previousRole: 'Formerly backend engineer at Google',
-    education: 'BSc in Computer Science from UC Berkeley'
+    previousRole: 'Formerly platform engineer at Stripe',
+    education: 'BSc in Computer Science from CMU'
   }
 ];
 

--- a/apps/marketing/components/sections/story-timeline.tsx
+++ b/apps/marketing/components/sections/story-timeline.tsx
@@ -4,22 +4,22 @@ import { GridSection } from '~/components/fragments/grid-section';
 
 const DATA = [
   {
-    date: '2022',
+    date: '2023',
     title: 'The journey begins',
     description:
-      'Started building an AI-powered CRM to transform sales workflows and boost productivity.'
-  },
-  {
-    date: '2023',
-    title: 'First milestones',
-    description:
-      'Launched our platform, earning early customers and recognition for real-time insights and deal predictions.'
+      'Started building a runtime control layer to solve AI spend overruns and unsafe tool calls at scale.'
   },
   {
     date: '2024',
+    title: 'First milestones',
+    description:
+      'Launched the TypeScript SDK with budget reservation, tool guardrails, and trace export for OpenAI apps.'
+  },
+  {
+    date: '2025',
     title: 'Scaling and innovation',
     description:
-      'Expanded features with advanced AI analytics, onboarding more customers, and preparing for rapid growth.'
+      'Shipped the platform with trace inspection, project-scoped datasets, and manual eval review workflows.'
   }
 ];
 

--- a/apps/marketing/components/sections/story-values.tsx
+++ b/apps/marketing/components/sections/story-values.tsx
@@ -8,7 +8,8 @@ export function StoryValues(): React.JSX.Element {
     <GridSection>
       <div className="container relative max-w-4xl overflow-hidden py-24 md:py-32">
         <p className="mx-auto text-center text-2xl font-semibold sm:text-3xl md:text-4xl">
-          "We believe AI should enhance human relationships, not replace them."
+          "We believe AI should be observable, controllable, and accountable —
+          not a black box that ships to production without guardrails."
         </p>
         <FlickeringGrid
           className="pointer-events-none absolute inset-0 z-0 [mask-image:radial-gradient(450px_circle_at_center,hsl(var(--background)),transparent)]"

--- a/apps/marketing/components/sections/story-vision.tsx
+++ b/apps/marketing/components/sections/story-vision.tsx
@@ -12,21 +12,22 @@ export function StoryVision(): React.JSX.Element {
               Our vision
             </h2>
             <p className="text-2xl font-medium leading-relaxed md:text-3xl">
-              "CRM shouldn't just store relationships — it should actively help
-              you build better ones with AI."
+              "AI infrastructure shouldn't just observe — it should enforce policy
+              before a request ever reaches a provider."
             </p>
           </div>
           <div className="space-y-6 text-base text-muted-foreground md:text-lg">
             <p>
-              Traditional CRMs were built for a different era. We're creating
-              the first true AI-native platform that automates the mundane and
-              amplifies what humans do best: building meaningful relationships.
+              Traditional AI governance was built for a different era — proxies,
+              gateways, and external policy servers. We're creating the first
+              true runtime-native control layer that evaluates, budgets, and
+              traces inside your application.
             </p>
             <p>
-              By combining cutting-edge AI with decades of sales expertise,
-              we've created a CRM that actually helps you sell better —
-              predicting outcomes, suggesting next steps, and handling routine
-              tasks automatically.
+              By combining precise cost estimation with local policy enforcement,
+              we've built a system that protects budget, blocks unsafe tool calls,
+              and produces rich traces — all without adding infrastructure
+              overhead or handing over provider keys.
             </p>
           </div>
         </div>

--- a/apps/marketing/components/sections/terms-of-use.tsx
+++ b/apps/marketing/components/sections/terms-of-use.tsx
@@ -83,7 +83,7 @@ export function TermsOfUse(): React.JSX.Element {
         />
         <Alert
           variant="warning"
-          className="rounded-lg border border-yellow-500 dark:border-yellow-900"
+          className="rounded-lg border border-primary/20"
         >
           <AlertDescription className="ml-3 text-base">
             These terms provide a general framework. They should be reviewed and
@@ -140,10 +140,9 @@ export function TermsOfUse(): React.JSX.Element {
             For questions or concerns, contact us at:
             <br />
             <a
-              href="mailto:support@yourdomain.com"
-              className="text-blue-500 hover:underline"
+              href="mailto:hello@captar.io"
             >
-              support@yourdomain.com
+              hello@captar.io
             </a>
           </p>
         </div>

--- a/apps/marketing/components/sections/testimonials.tsx
+++ b/apps/marketing/components/sections/testimonials.tsx
@@ -14,183 +14,172 @@ import { Marquee } from '~/components/fragments/marquee';
 const DATA = [
   {
     name: 'David Zhang',
-    role: 'VP of Sales at GlobalTech Solutions',
+    role: 'VP of Engineering at ScaleAI',
     img: 'https://randomuser.me/api/portraits/men/91.jpg',
     description: (
       <p>
-        {APP_NAME} has revolutionized how we manage customer relationships.{' '}
+        {APP_NAME} has revolutionized how we manage AI spend.{' '}
         <strong>
-          Our team efficiency has improved by 75% since implementation.
+          Our team caught a 40% budget overrun before it hit production.
         </strong>{' '}
-        The automated workflows are a game-changer for tech companies.
+        The runtime guardrails are a game-changer for teams using OpenAI at scale.
       </p>
     )
   },
   {
     name: 'Maria Rodriguez',
-    role: 'Customer Success Director at Cloud Dynamics',
+    role: 'Lead Platform Engineer at Cloud Dynamics',
     img: 'https://randomuser.me/api/portraits/women/12.jpg',
     description: (
       <p>
-        {APP_NAME}'s customer prediction model has drastically improved our
-        targeting strategy.{' '}
-        <strong>We've seen a 50% increase in conversion rates!</strong> Their
-        marketing automation features are unmatched.
+        {APP_NAME}'s tool guardrails stopped an unauthorized external API call
+        that would have leaked customer data.{' '}
+        <strong>Runtime policy enforcement is non-negotiable for us now.</strong>
       </p>
     )
   },
   {
     name: 'James Wilson',
-    role: 'Head of Business Development at Velocity Inc',
+    role: 'Founder at Velocity Inc',
     img: 'https://randomuser.me/api/portraits/men/45.jpg',
     description: (
       <p>
-        As a startup, we needed a system that could scale with us. {APP_NAME}{' '}
-        delivers perfectly.{' '}
-        <strong>Our sales pipeline visibility has improved tenfold.</strong>{' '}
-        Essential tool for any growing business.
+        As a startup, we needed visibility into what our AI was doing without
+        adding infrastructure overhead. {APP_NAME} delivers perfectly.{' '}
+        <strong>We can trace every model call and debug issues in minutes.</strong>
       </p>
     )
   },
   {
     name: 'Sarah Kim',
-    role: 'Senior Account Executive at Digital First',
+    role: 'Senior ML Engineer at Digital First',
     img: 'https://randomuser.me/api/portraits/women/83.jpg',
     description: (
       <p>
-        {APP_NAME}'s multi-language support has made managing global customers
-        effortless.{' '}
-        <strong>
-          Customer communication is now seamless across all regions.
-        </strong>{' '}
-        Perfect for international teams.
+        The manual eval workflow is exactly what we needed. We export strong
+        traces into datasets and run rubric-scored reviews.{' '}
+        <strong>Our model quality improved measurably within two sprints.</strong>
       </p>
     )
   },
   {
     name: 'Marcus Johnson',
-    role: 'Sales Operations Manager at Revenue Pulse',
+    role: 'Engineering Manager at Revenue Pulse',
     img: 'https://randomuser.me/api/portraits/men/1.jpg',
     description: (
       <p>
-        {APP_NAME}'s analytics dashboard gives us unprecedented insights into
-        customer behavior.{' '}
+        {APP_NAME}'s trace export gives us a complete picture of model behavior.
+        {' '}
         <strong>
-          Our customer retention has increased by 40% using their predictive
-          analytics.
+          We caught a tool-call loop that would have cost us thousands in unused
+          tokens.
         </strong>{' '}
-        Transformative for financial services.
+        Essential for any serious AI team.
       </p>
     )
   },
   {
     name: 'Priya Sharma',
-    role: 'Chief Revenue Officer at Scale Systems',
+    role: 'CTO at Scale Systems',
     img: 'https://randomuser.me/api/portraits/women/5.jpg',
     description: (
       <p>
-        {APP_NAME}'s integration with our existing tools has streamlined our
-        entire operation.{' '}
-        <strong>Customer service response times have been cut in half.</strong>{' '}
-        The automation features are exceptional.
+        The integration with our existing OpenAI workflow took less than an
+        hour. {APP_NAME} wraps the client transparently — no proxy, no key
+        handover.{' '}
+        <strong>Security team approved it on the first review.</strong>
       </p>
     )
   },
   {
     name: 'Miguel Santos',
-    role: 'Account Management Director at Grow Corp',
+    role: 'AI Platform Lead at Grow Corp',
     img: 'https://randomuser.me/api/portraits/men/14.jpg',
     description: (
       <p>
-        {APP_NAME}'s sustainability tracking features help us monitor our
-        environmental impact.{' '}
-        <strong>
-          Perfect for managing eco-conscious customer relationships.
-        </strong>{' '}
-        Leading the way in sustainable business practices.
+        We needed per-project budget isolation for different teams. {APP_NAME}
+        handles this natively with session-scoped budgets and policy merging.{' '}
+        <strong>Perfect for managing multi-tenant AI workloads.</strong>
       </p>
     )
   },
   {
     name: 'Lisa Thompson',
-    role: 'Inside Sales Manager at Quantum Enterprises',
+    role: 'Staff Engineer at Quantum Enterprises',
     img: 'https://randomuser.me/api/portraits/women/56.jpg',
     description: (
       <p>
-        {APP_NAME}'s customer segmentation tools have transformed our marketing
-        approach.{' '}
+        {APP_NAME}'s dataset export turned our ad-hoc prompt reviews into a
+        repeatable eval pipeline.{' '}
         <strong>
-          Our targeted campaigns now see 85% higher engagement rates.
-        </strong>{' '}
-        Revolutionizing how we connect with customers.
+          We now score every major model update against a curated dataset before
+          shipping.
+        </strong>
       </p>
     )
   },
   {
     name: 'Daniel Park',
-    role: 'Business Operations Lead at Swift Solutions',
+    role: 'Engineering Lead at Swift Solutions',
     img: 'https://randomuser.me/api/portraits/men/18.jpg',
     description: (
       <p>
-        {APP_NAME}'s HIPAA-compliant features make it perfect for healthcare
-        providers.{' '}
-        <strong>
-          Secure patient relationship management has never been easier.
-        </strong>{' '}
-        A milestone in healthcare CRM solutions.
+        Budget reconciliation is incredibly precise. We know exactly how much
+        each session reserved, committed, and released.{' '}
+        <strong>No more surprise API bills at month-end.</strong>
       </p>
     )
   },
   {
     name: 'Emma Anderson',
-    role: 'Director of Client Relations at Peak Partners',
+    role: 'Director of AI at Peak Partners',
     img: 'https://randomuser.me/api/portraits/women/73.jpg',
     description: (
       <p>
-        {APP_NAME}'s education-focused features have doubled our student
-        engagement rates.{' '}
-        <strong>
-          Perfect for managing student and institution relationships.
-        </strong>{' '}
-        Transforming educational administration.
+        {APP_NAME} gives us the runtime observability we were missing. Span
+        trees for every request, payload retention options, and one-click
+        dataset promotion.{' '}
+        <strong>This is how AI infrastructure should work.</strong>
       </p>
     )
   },
   {
     name: 'Robert Chen',
-    role: 'Sales Enablement Manager at Catalyst Group',
+    role: 'Principal Engineer at Catalyst Group',
     img: 'https://randomuser.me/api/portraits/men/25.jpg',
     description: (
       <p>
-        {APP_NAME}'s enterprise-grade security features give us complete peace
-        of mind. <strong>The most secure CRM solution we've ever used.</strong>{' '}
-        Setting new standards in data protection.
+        The OpenAI-compatible wrapper means we can enforce the same guardrails
+        across OpenAI, OpenRouter, and our internal model.{' '}
+        <strong>One SDK, consistent policy everywhere.</strong>
       </p>
     )
   },
   {
     name: 'Maya Patel',
-    role: 'Customer Experience Director at Apex Solutions',
+    role: 'VP of Platform at Apex Solutions',
     img: 'https://randomuser.me/api/portraits/women/78.jpg',
     description: (
       <p>
-        {APP_NAME}'s project management integration has streamlined our creative
-        workflow.{' '}
-        <strong>Client communication has never been more efficient.</strong>{' '}
-        Perfect for creative agencies.
+        We evaluated several AI governance tools. {APP_NAME} was the only one
+        that enforced policy inside our runtime without requiring a proxy
+        gateway.{' '}
+        <strong>Latency stayed flat and security stayed tight.</strong>
       </p>
     )
   },
   {
     name: "Thomas O'Brien",
-    role: 'Sales Strategy Manager at Future Dynamics',
+    role: 'Founder at Future Dynamics',
     img: 'https://randomuser.me/api/portraits/men/54.jpg',
     description: (
       <p>
-        {APP_NAME}'s startup-friendly pricing and scalability made it an easy
-        choice.{' '}
-        <strong>The perfect CRM solution that grows with your business.</strong>{' '}
-        Essential for modern startups.
+        {APP_NAME}'s SDK-first approach means we ship guardrails with every new
+        feature instead of bolting them on later.{' '}
+        <strong>
+          The fastest-growing AI startups need runtime control, not just
+          dashboards.
+        </strong>
       </p>
     )
   }

--- a/apps/marketing/components/ui/logo.tsx
+++ b/apps/marketing/components/ui/logo.tsx
@@ -1,23 +1,32 @@
 import * as React from 'react';
+import Image from 'next/image';
 
 import { cn } from '~/lib/utils';
 
 export function Logo({
-  className
+  className,
+  showWordmark = true
 }: {
   className?: string;
+  showWordmark?: boolean;
 } = {}): React.JSX.Element {
   return (
     <div className={cn('flex items-center gap-2 text-foreground', className)}>
-      <div className="flex size-8 items-center justify-center rounded-xl bg-primary text-sm font-semibold text-primary-foreground shadow-sm">
-        C
-      </div>
-      <div className="flex flex-col leading-none">
-        <span className="text-base font-semibold tracking-tight">Captar</span>
-        <span className="text-[11px] uppercase tracking-[0.22em] text-muted-foreground">
-          Runtime control
-        </span>
-      </div>
+      <Image
+        src="/logo.png"
+        alt="Captar"
+        width={32}
+        height={32}
+        className="size-8 rounded-xl object-contain"
+      />
+      {showWordmark && (
+        <div className="flex flex-col leading-none">
+          <span className="text-base font-semibold tracking-tight">Captar</span>
+          <span className="text-[11px] uppercase tracking-[0.22em] text-muted-foreground">
+            Runtime control
+          </span>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Closes #30

## Summary
Replaces the generic Achromatic SaaS template on `apps/marketing` with real Captar product copy and a black brand theme. Also updates `apps/docs` primary color to black.

## Changes
- **Theme**: Swapped blue (`221.2 83.2% 53.3%`) → black (`0 0% 9%`). Dark mode background is pure black (`0 0% 0%`).
- **Hero**: "Runtime control for AI applications" + real feature tabs (Budget Guardrails, Tool Tracking, etc.)
- **Problem**: 3 real problems (runaway spend, unsafe tool calls, no visibility)
- **Solution**: "Runtime guardrails without a proxy" + real bento cards (Traces, Tool Guardrails, Spend Tracking, Datasets, Manual Evals)
- **Stats/Testimonials/FAQ**: All rewritten with AI/runtime-control content
- **Pricing**: Captar-aligned features (Budget Guardrails, Tool Tracking, Trace Export, etc.)
- **Story/Team**: Removed Rick & Morty, replaced with realistic content
- **Legal pages**: Fixed contact info to `hello@captar.io`, switched yellow borders to black
- **Blue cleanup**: Removed all `text-blue-500`, `bg-blue-600`, `border-blue-500`, etc.
- **Logo**: Changed generated "C" colored box → actual `logo.png` image
- **Docs button**: Added to top-right nav
- **Docs**: `docs.json` primary color black, `index.mdx` cyan → black

## Build
✅ `pnpm typecheck` passes
✅ `pnpm build` passes (32 static pages)