### PR TITLE
feat: stabilize SDK public API surface and add hooks (#32)

### DIFF
--- a/packages/ts/sdk/src/index.ts
+++ b/packages/ts/sdk/src/index.ts
@@ -473,6 +473,20 @@ export function createCaptar(options: CaptarOptions): CaptarInstance {
                   span: finalSpan,
                 }
               );
+              if (error instanceof BudgetExceededError && options.onBudgetExceeded) {
+                options.onBudgetExceeded({
+                  sessionId: session.trace.traceId,
+                  budgetUsd: session.getSummary().totalReservedUsd,
+                  attemptedUsd: estimate.estimatedCostUsd ?? 0,
+                });
+              }
+              if (error instanceof PolicyViolationError && options.onPolicyViolation) {
+                options.onPolicyViolation({
+                  sessionId: session.trace.traceId,
+                  reason: error.message,
+                  type: error instanceof PolicyViolationError ? 'blocked' : 'violation',
+                });
+              }
               throw error;
             }
 

--- a/packages/ts/sdk/src/index.ts
+++ b/packages/ts/sdk/src/index.ts
@@ -1,5 +1,6 @@
-import { defaultSessionPolicy, getCaptarEnvConfig } from "@captar/config";
+import { defaultSessionPolicy, getCaptarEnvConfig } from '@captar/config';
 import type {
+  CaptarEvent,
   CaptarOptions,
   CaptarSession,
   ControlPlaneHook,
@@ -7,22 +8,68 @@ import type {
   OpenAIWrapOptions,
   SessionPolicy,
   StartSessionOptions,
+  ToolHandle,
   TrackToolOptions,
-} from "@captar/types";
-import { createId } from "@captar/utils";
+} from '@captar/types';
+import { createId } from '@captar/utils';
 
-import { BudgetExceededError, PolicyViolationError } from "./internal/errors.js";
-import { EventBus } from "./internal/event-bus.js";
-import { HttpBatchExporter, NoopExporter } from "./internal/exporter.js";
-import { OpenAIAdapter } from "./internal/openai-adapter.js";
-import { PolicyEngine } from "./internal/policy-engine.js";
-import { PricingRegistry } from "./internal/pricing-registry.js";
-import { RuntimeSession } from "./internal/session.js";
-import { createSpanSnapshot, updateSpanSnapshot } from "./internal/span.js";
-import { createTrackedTool } from "./internal/tools.js";
+import { BudgetExceededError, PolicyViolationError } from './internal/errors.js';
+import { EventBus } from './internal/event-bus.js';
+import { HttpBatchExporter, NoopExporter } from './internal/exporter.js';
+import { OpenAIAdapter } from './internal/openai-adapter.js';
+import { PolicyEngine } from './internal/policy-engine.js';
+import { PricingRegistry } from './internal/pricing-registry.js';
+import { RuntimeSession } from './internal/session.js';
+import { createSpanSnapshot, updateSpanSnapshot } from './internal/span.js';
+import { createTrackedTool } from './internal/tools.js';
 
-export * from "@captar/types";
-export { eventToSpanRecord } from "./internal/telemetry.js";
+export * from '@captar/types';
+export { BudgetExceededError, PolicyViolationError };
+
+export { eventToSpanRecord } from './internal/telemetry.js';
+
+export interface CaptarInstance {
+  /**
+   * Subscribe to all Captar runtime events.
+   * @param listener - Called for every event emitted during execution
+   * @returns Unsubscribe function
+   */
+  onEvent(listener: (event: CaptarEvent) => void | Promise<void>): () => void;
+
+  /**
+   * Start a new budgeted session for a single conversation or tool execution.
+   * @param sessionOptions - Override budgets, metadata, and policies for this session
+   * @returns Active session ready for wrapping OpenAI or tracked tools
+   */
+  startSession(sessionOptions?: StartSessionOptions): Promise<CaptarSession>;
+
+  /**
+   * Wrap an OpenAI-compatible client with budget, policy, and span tracking.
+   * @param client - The client to wrap (e.g. OpenAI.Chat.Completions)
+   * @param wrapOptions - Session and optional per-call policy overrides
+   * @returns The client with all methods instrumented
+   */
+  wrapOpenAI<TClient extends Record<string, unknown>>(
+    client: TClient,
+    wrapOptions: OpenAIWrapOptions
+  ): TClient;
+
+  /**
+   * Create a tracked version of a tool function with guardrails and telemetry.
+   * @param name - Tool name used in spans and policy matching
+   * @param toolOptions - Handler, args schema, result schema, and optional policy
+   * @returns Tracked tool handler (call `.run()` to execute)
+   */
+  trackTool<TArgs, TResult>(
+    name: string,
+    toolOptions: TrackToolOptions<TArgs, TResult>
+  ): ToolHandle<TResult>;
+
+  /**
+   * Drain the internal exporter queue and wait for pending batches.
+   */
+  flush(): Promise<void>;
+}
 
 function createExporter(options: CaptarOptions): Exporter | HttpBatchExporter {
   const exporterProject = options.project;
@@ -41,7 +88,7 @@ function createExporter(options: CaptarOptions): Exporter | HttpBatchExporter {
     return new NoopExporter();
   }
 
-  if ("export" in options.exporter) {
+  if ('export' in options.exporter) {
     return options.exporter;
   }
 
@@ -50,7 +97,7 @@ function createExporter(options: CaptarOptions): Exporter | HttpBatchExporter {
 
 function mergePolicy(
   base: SessionPolicy | undefined,
-  override: SessionPolicy | undefined,
+  override: SessionPolicy | undefined
 ): SessionPolicy | undefined {
   if (!base && !override) {
     return undefined;
@@ -63,30 +110,24 @@ function mergePolicy(
   };
 }
 
-async function fetchControlPlanePolicy(
-  options: CaptarOptions,
-): Promise<SessionPolicy | undefined> {
+async function fetchControlPlanePolicy(options: CaptarOptions): Promise<SessionPolicy | undefined> {
   const controlPlane = options.controlPlane;
   if (!controlPlane?.syncPolicy) {
     return undefined;
   }
 
-  const baseUrl = controlPlane.baseUrl ?? "http://localhost:3000";
+  const baseUrl = controlPlane.baseUrl ?? 'http://localhost:3000';
   const response = await fetch(
-    `${baseUrl.replace(/\/$/, "")}/api/hooks/${controlPlane.hookId}/policy`,
+    `${baseUrl.replace(/\/$/, '')}/api/hooks/${controlPlane.hookId}/policy`,
     {
       headers: {
-        ...(controlPlane.apiKey
-          ? { authorization: `Bearer ${controlPlane.apiKey}` }
-          : {}),
+        ...(controlPlane.apiKey ? { authorization: `Bearer ${controlPlane.apiKey}` } : {}),
       },
-    },
+    }
   );
 
   if (!response.ok) {
-    throw new Error(
-      `Failed to load control-plane policy for ${controlPlane.hookId}.`,
-    );
+    throw new Error(`Failed to load control-plane policy for ${controlPlane.hookId}.`);
   }
 
   const payload = (await response.json()) as { hook: ControlPlaneHook };
@@ -98,15 +139,20 @@ function isBlockedExecutionError(error: unknown): boolean {
 }
 
 function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : "unknown error";
+  return error instanceof Error ? error.message : 'unknown error';
 }
 
-export function createCaptar(options: CaptarOptions) {
+/**
+ * Create a Captar runtime instance with budget tracking, policy enforcement, and telemetry export.
+ * @param options - Global project config, control plane, exporter, and default policies
+ * @returns Captar instance for sessions, OpenAI wrapping, and tool tracking
+ */
+export function createCaptar(options: CaptarOptions): CaptarInstance {
   const bus = new EventBus();
   const exporter = createExporter(options);
   const pricingRegistry = new PricingRegistry(
-    options.pricing ?? "builtin",
-    options.pricingOverrides,
+    options.pricing ?? 'builtin',
+    options.pricingOverrides
   );
 
   return {
@@ -117,17 +163,12 @@ export function createCaptar(options: CaptarOptions) {
     async startSession(sessionOptions: StartSessionOptions = {}): Promise<CaptarSession> {
       const remotePolicy = await fetchControlPlanePolicy(options);
       const policy = mergePolicy(
-        mergePolicy(
-          mergePolicy(defaultSessionPolicy, options.defaultPolicy),
-          remotePolicy,
-        ),
-        sessionOptions.policy,
+        mergePolicy(mergePolicy(defaultSessionPolicy, options.defaultPolicy), remotePolicy),
+        sessionOptions.policy
       );
       const metadata = {
         ...sessionOptions.metadata,
-        ...(options.controlPlane
-          ? { _captarHookId: options.controlPlane.hookId }
-          : {}),
+        ...(options.controlPlane ? { _captarHookId: options.controlPlane.hookId } : {}),
       };
       const session = new RuntimeSession(
         options.project,
@@ -138,7 +179,7 @@ export function createCaptar(options: CaptarOptions) {
         metadata,
         policy,
         bus,
-        exporter as HttpBatchExporter | NoopExporter,
+        exporter as HttpBatchExporter | NoopExporter
       );
       await session.initialize();
       return session;
@@ -146,7 +187,7 @@ export function createCaptar(options: CaptarOptions) {
 
     wrapOpenAI<TClient extends Record<string, any>>(
       client: TClient,
-      wrapOptions: OpenAIWrapOptions,
+      wrapOptions: OpenAIWrapOptions
     ): TClient {
       const session = wrapOptions.session as RuntimeSession;
       const policy = mergePolicy(session.policy, wrapOptions.policy);
@@ -155,22 +196,18 @@ export function createCaptar(options: CaptarOptions) {
       const wrapMethod = (
         namespace: string,
         methodName: string,
-        invoke: (request: Record<string, unknown>) => Promise<any>,
+        invoke: (request: Record<string, unknown>) => Promise<any>
       ) => {
         return async (request: Record<string, unknown>) => {
-          const adapter = new OpenAIAdapter(
-            pricingRegistry,
-            invoke,
-            policy?.call?.timeoutMs,
-          );
+          const adapter = new OpenAIAdapter(pricingRegistry, invoke, policy?.call?.timeoutMs);
           const estimate = await adapter.estimate(request);
-          const requestId = createId("req");
+          const requestId = createId('req');
           const requestSpan = createSpanSnapshot({
             parentId: session.trace.spanId,
             name: `${namespace}.${methodName}`,
-            kind: "request",
+            kind: 'request',
             attributes: {
-              provider: "openai",
+              provider: 'openai',
               model: estimate.model,
               namespace,
               methodName,
@@ -181,9 +218,9 @@ export function createCaptar(options: CaptarOptions) {
           let reservedUsd = 0;
           session.markRequest(false);
           await session.emit(
-            "request.started",
+            'request.started',
             {
-              provider: "openai",
+              provider: 'openai',
               model: estimate.model,
               requestId,
               namespace,
@@ -194,15 +231,15 @@ export function createCaptar(options: CaptarOptions) {
               spanId: requestSpan.id,
               parentSpanId: requestSpan.parentId,
               span: requestSpan,
-            },
+            }
           );
 
           try {
             policyEngine.evaluateCall(request, policy, estimate.estimatedCostUsd);
             await session.emit(
-              "request.allowed",
+              'request.allowed',
               {
-                provider: "openai",
+                provider: 'openai',
                 model: estimate.model,
                 estimatedCostUsd: estimate.estimatedCostUsd,
               },
@@ -210,16 +247,16 @@ export function createCaptar(options: CaptarOptions) {
                 spanId: requestSpan.id,
                 parentSpanId: requestSpan.parentId,
                 span: requestSpan,
-              },
+              }
             );
 
             reservedUsd = session.reserve(estimate.estimatedCostUsd, {
               label: methodName,
             });
             await session.emit(
-              "estimate.reserved",
+              'estimate.reserved',
               {
-                provider: "openai",
+                provider: 'openai',
                 model: estimate.model,
                 reservedUsd,
               },
@@ -227,14 +264,14 @@ export function createCaptar(options: CaptarOptions) {
                 spanId: requestSpan.id,
                 parentSpanId: requestSpan.parentId,
                 span: requestSpan,
-              },
+              }
             );
 
             const response = await adapter.execute(request);
 
             if (
               request.stream &&
-              typeof response === "object" &&
+              typeof response === 'object' &&
               response !== null &&
               Symbol.asyncIterator in response
             ) {
@@ -245,7 +282,7 @@ export function createCaptar(options: CaptarOptions) {
                   try {
                     for await (const chunk of stream) {
                       const usage = chunk.usage;
-                      if (usage && typeof usage === "object") {
+                      if (usage && typeof usage === 'object') {
                         chunks.push(usage as Partial<Record<string, number>>);
                       }
                       yield chunk;
@@ -253,7 +290,7 @@ export function createCaptar(options: CaptarOptions) {
                   } catch (error) {
                     const endedAt = new Date().toISOString();
                     const failedSpan = updateSpanSnapshot(requestSpan, {
-                      status: "failed",
+                      status: 'failed',
                       endedAt,
                       attributes: {
                         error: errorMessage(error),
@@ -264,9 +301,9 @@ export function createCaptar(options: CaptarOptions) {
                       const reconciliation = session.commit(reservedUsd, 0);
                       reservedUsd = 0;
                       await session.emit(
-                        "spend.committed",
+                        'spend.committed',
                         {
-                          provider: "openai",
+                          provider: 'openai',
                           model: estimate.model,
                           actualCostUsd: reconciliation.actualUsd,
                           releasedUsd: reconciliation.releasedUsd,
@@ -275,22 +312,22 @@ export function createCaptar(options: CaptarOptions) {
                           spanId: requestSpan.id,
                           parentSpanId: requestSpan.parentId,
                           span: failedSpan,
-                        },
+                        }
                       );
                     }
 
                     await session.emit(
-                      "request.failed",
+                      'request.failed',
                       {
                         reason: errorMessage(error),
-                        provider: "openai",
+                        provider: 'openai',
                         model: estimate.model,
                       },
                       {
                         spanId: requestSpan.id,
                         parentSpanId: requestSpan.parentId,
                         span: failedSpan,
-                      },
+                      }
                     );
                     throw error;
                   }
@@ -299,10 +336,10 @@ export function createCaptar(options: CaptarOptions) {
                   const actualUsage = adapter.extractStreamUsage(
                     estimate.model,
                     chunks,
-                    estimate.estimatedCostUsd,
+                    estimate.estimatedCostUsd
                   );
                   const completedSpan = updateSpanSnapshot(requestSpan, {
-                    status: "completed",
+                    status: 'completed',
                     endedAt,
                     attributes: {
                       model: actualUsage.model,
@@ -312,13 +349,10 @@ export function createCaptar(options: CaptarOptions) {
                       costUsd: actualUsage.costUsd,
                     },
                   });
-                  const reconciliation = session.commit(
-                    reservedUsd,
-                    actualUsage.costUsd,
-                  );
+                  const reconciliation = session.commit(reservedUsd, actualUsage.costUsd);
                   reservedUsd = 0;
                   await session.emit(
-                    "provider.response",
+                    'provider.response',
                     {
                       ...actualUsage,
                       response,
@@ -327,12 +361,12 @@ export function createCaptar(options: CaptarOptions) {
                       spanId: requestSpan.id,
                       parentSpanId: requestSpan.parentId,
                       span: completedSpan,
-                    },
+                    }
                   );
                   await session.emit(
-                    "spend.committed",
+                    'spend.committed',
                     {
-                      provider: "openai",
+                      provider: 'openai',
                       model: actualUsage.model,
                       actualCostUsd: reconciliation.actualUsd,
                       releasedUsd: reconciliation.releasedUsd,
@@ -341,7 +375,7 @@ export function createCaptar(options: CaptarOptions) {
                       spanId: requestSpan.id,
                       parentSpanId: requestSpan.parentId,
                       span: completedSpan,
-                    },
+                    }
                   );
                 },
               };
@@ -352,10 +386,10 @@ export function createCaptar(options: CaptarOptions) {
             const endedAt = new Date().toISOString();
             const actualUsage = adapter.extractUsage(
               response as Record<string, unknown>,
-              estimate.estimatedCostUsd,
+              estimate.estimatedCostUsd
             );
             const completedSpan = updateSpanSnapshot(requestSpan, {
-              status: "completed",
+              status: 'completed',
               endedAt,
               attributes: {
                 model: actualUsage.model,
@@ -368,7 +402,7 @@ export function createCaptar(options: CaptarOptions) {
             const reconciliation = session.commit(reservedUsd, actualUsage.costUsd);
             reservedUsd = 0;
             await session.emit(
-              "provider.response",
+              'provider.response',
               {
                 ...actualUsage,
                 response,
@@ -377,12 +411,12 @@ export function createCaptar(options: CaptarOptions) {
                 spanId: requestSpan.id,
                 parentSpanId: requestSpan.parentId,
                 span: completedSpan,
-              },
+              }
             );
             await session.emit(
-              "spend.committed",
+              'spend.committed',
               {
-                provider: "openai",
+                provider: 'openai',
                 model: actualUsage.model,
                 actualCostUsd: reconciliation.actualUsd,
                 releasedUsd: reconciliation.releasedUsd,
@@ -391,14 +425,14 @@ export function createCaptar(options: CaptarOptions) {
                 spanId: requestSpan.id,
                 parentSpanId: requestSpan.parentId,
                 span: completedSpan,
-              },
+              }
             );
             return response;
           } catch (error) {
             const endedAt = new Date().toISOString();
             const blocked = isBlockedExecutionError(error);
             const finalSpan = updateSpanSnapshot(requestSpan, {
-              status: blocked ? "blocked" : "failed",
+              status: blocked ? 'blocked' : 'failed',
               endedAt,
               attributes: {
                 error: errorMessage(error),
@@ -409,9 +443,9 @@ export function createCaptar(options: CaptarOptions) {
               const reconciliation = session.commit(reservedUsd, 0);
               reservedUsd = 0;
               await session.emit(
-                "spend.committed",
+                'spend.committed',
                 {
-                  provider: "openai",
+                  provider: 'openai',
                   model: estimate.model,
                   actualCostUsd: reconciliation.actualUsd,
                   releasedUsd: reconciliation.releasedUsd,
@@ -420,36 +454,40 @@ export function createCaptar(options: CaptarOptions) {
                   spanId: requestSpan.id,
                   parentSpanId: requestSpan.parentId,
                   span: finalSpan,
-                },
+                }
               );
             }
 
             if (blocked) {
               session.markRequest(true);
-              await session.emit("request.blocked", {
-                reason: error instanceof Error ? error.message : "blocked",
-                provider: "openai",
-                model: estimate.model,
-              }, {
-                spanId: requestSpan.id,
-                parentSpanId: requestSpan.parentId,
-                span: finalSpan,
-              });
+              await session.emit(
+                'request.blocked',
+                {
+                  reason: error instanceof Error ? error.message : 'blocked',
+                  provider: 'openai',
+                  model: estimate.model,
+                },
+                {
+                  spanId: requestSpan.id,
+                  parentSpanId: requestSpan.parentId,
+                  span: finalSpan,
+                }
+              );
               throw error;
             }
 
             await session.emit(
-              "request.failed",
+              'request.failed',
               {
                 reason: errorMessage(error),
-                provider: "openai",
+                provider: 'openai',
                 model: estimate.model,
               },
               {
                 spanId: requestSpan.id,
                 parentSpanId: requestSpan.parentId,
                 span: finalSpan,
-              },
+              }
             );
             throw error;
           }
@@ -460,16 +498,14 @@ export function createCaptar(options: CaptarOptions) {
         ...client,
         responses: {
           ...client.responses,
-          create: wrapMethod("responses", "create", (request) =>
-            client.responses.create(request),
-          ),
+          create: wrapMethod('responses', 'create', (request) => client.responses.create(request)),
         },
         chat: {
           ...client.chat,
           completions: {
             ...client.chat?.completions,
-            create: wrapMethod("chat.completions", "create", (request) =>
-              client.chat.completions.create(request),
+            create: wrapMethod('chat.completions', 'create', (request) =>
+              client.chat.completions.create(request)
             ),
           },
         },
@@ -478,15 +514,12 @@ export function createCaptar(options: CaptarOptions) {
       return wrapped;
     },
 
-    trackTool<TArgs, TResult>(
-      name: string,
-      toolOptions: TrackToolOptions<TArgs, TResult>,
-    ) {
+    trackTool<TArgs, TResult>(name: string, toolOptions: TrackToolOptions<TArgs, TResult>) {
       return createTrackedTool(name, toolOptions, new PolicyEngine());
     },
 
     async flush(): Promise<void> {
-      if ("flush" in exporter && exporter.flush) {
+      if ('flush' in exporter && exporter.flush) {
         await exporter.flush();
       }
     },

--- a/packages/ts/sdk/test/runtime-controller.test.ts
+++ b/packages/ts/sdk/test/runtime-controller.test.ts
@@ -1,11 +1,11 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from 'vitest';
 
-import { createCaptar, type CaptarEvent } from "../src/index.js";
+import { createCaptar, type CaptarEvent } from '../src/index.js';
 
-describe("createCaptar", () => {
-  it("emits a stable request span hierarchy and reconciles spend", async () => {
+describe('createCaptar', () => {
+  it('emits a stable request span hierarchy and reconciles spend', async () => {
     const captar = createCaptar({
-      project: "support-bot",
+      project: 'support-bot',
     });
     const events: CaptarEvent[] = [];
     captar.onEvent((event) => {
@@ -22,7 +22,7 @@ describe("createCaptar", () => {
     const client = {
       responses: {
         create: vi.fn(async () => ({
-          model: "gpt-4.1-mini",
+          model: 'gpt-4.1-mini',
           usage: {
             input_tokens: 100,
             output_tokens: 50,
@@ -32,7 +32,7 @@ describe("createCaptar", () => {
       chat: {
         completions: {
           create: vi.fn(async () => ({
-            model: "gpt-4.1-mini",
+            model: 'gpt-4.1-mini',
             usage: {
               prompt_tokens: 50,
               completion_tokens: 25,
@@ -44,8 +44,8 @@ describe("createCaptar", () => {
 
     const openai = captar.wrapOpenAI(client, { session });
     await openai.responses.create({
-      model: "gpt-4.1-mini",
-      input: "hello",
+      model: 'gpt-4.1-mini',
+      input: 'hello',
       max_output_tokens: 120,
     });
 
@@ -53,16 +53,20 @@ describe("createCaptar", () => {
     expect(state.committedUsd).toBeGreaterThan(0);
     expect(state.reservedUsd).toBe(0);
 
-    const requestEvents = events.filter((event) => event.span?.kind === "request");
+    const requestEvents = events.filter((event) => event.span?.kind === 'request');
     expect(requestEvents.length).toBeGreaterThan(0);
     expect(new Set(requestEvents.map((event) => event.trace.spanId)).size).toBe(1);
-    expect(requestEvents.every((event) => event.trace.parentSpanId === session.trace.spanId)).toBe(true);
-    expect(events.find((event) => event.type === "provider.response")?.span?.status).toBe("completed");
+    expect(requestEvents.every((event) => event.trace.parentSpanId === session.trace.spanId)).toBe(
+      true
+    );
+    expect(events.find((event) => event.type === 'provider.response')?.span?.status).toBe(
+      'completed'
+    );
   });
 
-  it("blocks disallowed models before making the provider call", async () => {
+  it('blocks disallowed models before making the provider call', async () => {
     const captar = createCaptar({
-      project: "support-bot",
+      project: 'support-bot',
     });
     const events: CaptarEvent[] = [];
     captar.onEvent((event) => {
@@ -73,7 +77,7 @@ describe("createCaptar", () => {
       budget: { maxSpendUsd: 1 },
       policy: {
         call: {
-          allowedModels: ["gpt-4.1-mini"],
+          allowedModels: ['gpt-4.1-mini'],
         },
       },
     });
@@ -81,7 +85,7 @@ describe("createCaptar", () => {
     const client = {
       responses: {
         create: vi.fn(async () => ({
-          model: "gpt-4.1",
+          model: 'gpt-4.1',
         })),
       },
       chat: {
@@ -95,18 +99,18 @@ describe("createCaptar", () => {
 
     await expect(
       openai.responses.create({
-        model: "gpt-4.1",
-        input: "hello",
-      }),
+        model: 'gpt-4.1',
+        input: 'hello',
+      })
     ).rejects.toThrow(/allow list/);
     expect(client.responses.create).not.toHaveBeenCalled();
     expect(session.getSummary().blockedCount).toBe(1);
-    expect(events.find((event) => event.type === "request.blocked")?.span?.status).toBe("blocked");
+    expect(events.find((event) => event.type === 'request.blocked')?.span?.status).toBe('blocked');
   });
 
-  it("releases reserved spend and emits request.failed on provider errors", async () => {
+  it('releases reserved spend and emits request.failed on provider errors', async () => {
     const captar = createCaptar({
-      project: "support-bot",
+      project: 'support-bot',
     });
     const events: CaptarEvent[] = [];
     captar.onEvent((event) => {
@@ -119,7 +123,7 @@ describe("createCaptar", () => {
     const client = {
       responses: {
         create: vi.fn(async () => {
-          throw new Error("provider unavailable");
+          throw new Error('provider unavailable');
         }),
       },
       chat: {
@@ -133,48 +137,48 @@ describe("createCaptar", () => {
 
     await expect(
       openai.responses.create({
-        model: "gpt-4.1-mini",
-        input: "hello",
+        model: 'gpt-4.1-mini',
+        input: 'hello',
         max_output_tokens: 120,
-      }),
+      })
     ).rejects.toThrow(/provider unavailable/);
 
     expect(session.getState().reservedUsd).toBe(0);
-    expect(events.find((event) => event.type === "request.failed")?.span?.status).toBe("failed");
+    expect(events.find((event) => event.type === 'request.failed')?.span?.status).toBe('failed');
     expect(
-      events.find((event) => event.type === "spend.committed")?.data.releasedUsd,
+      events.find((event) => event.type === 'spend.committed')?.data.releasedUsd
     ).toBeGreaterThan(0);
   });
 
-  it("tracks tool costs and preserves approval hooks", async () => {
+  it('tracks tool costs and preserves approval hooks', async () => {
     const captar = createCaptar({
-      project: "support-bot",
+      project: 'support-bot',
     });
     const session = await captar.startSession({
       budget: { maxSpendUsd: 2 },
       policy: {
         tool: {
-          requireApprovalFor: ["zendesk.createComment"],
+          requireApprovalFor: ['zendesk.createComment'],
         },
       },
     });
 
-    const tool = captar.trackTool("zendesk.createComment", {
+    const tool = captar.trackTool('zendesk.createComment', {
       session,
       estimate: 0.25,
       actual: 0.1,
       approval: true,
     });
 
-    const result = await tool.run(async () => "ok");
-    expect(result).toBe("ok");
+    const result = await tool.run(async () => 'ok');
+    expect(result).toBe('ok');
     expect(session.getSummary().toolCallCount).toBe(1);
     expect(session.getSummary().totalCommittedUsd).toBe(0.1);
   });
 
-  it("releases reserved tool spend and emits tool.failed on tool errors", async () => {
+  it('releases reserved tool spend and emits tool.failed on tool errors', async () => {
     const captar = createCaptar({
-      project: "support-bot",
+      project: 'support-bot',
     });
     const events: CaptarEvent[] = [];
     captar.onEvent((event) => {
@@ -184,7 +188,7 @@ describe("createCaptar", () => {
       budget: { maxSpendUsd: 2 },
     });
 
-    const tool = captar.trackTool("search.docs", {
+    const tool = captar.trackTool('search.docs', {
       session,
       estimate: 0.25,
       actual: 0.1,
@@ -192,16 +196,63 @@ describe("createCaptar", () => {
 
     await expect(
       tool.run(async () => {
-        throw new Error("tool crashed");
-      }),
+        throw new Error('tool crashed');
+      })
     ).rejects.toThrow(/tool crashed/);
 
     expect(session.getState().reservedUsd).toBe(0);
-    expect(events.find((event) => event.type === "tool.failed")?.span?.status).toBe("failed");
+    expect(events.find((event) => event.type === 'tool.failed')?.span?.status).toBe('failed');
     expect(
       events
-        .filter((event) => event.type === "spend.committed")
-        .some((event) => Number(event.data.releasedUsd ?? 0) > 0),
+        .filter((event) => event.type === 'spend.committed')
+        .some((event) => Number(event.data.releasedUsd ?? 0) > 0)
     ).toBe(true);
+  });
+});
+
+describe('hooks', () => {
+  it('calls onPolicyViolation when call is blocked by policy', async () => {
+    const onPolicyViolation = vi.fn();
+    const captar = createCaptar({
+      project: 'test',
+      onPolicyViolation,
+    });
+
+    const events: CaptarEvent[] = [];
+    captar.onEvent((event) => events.push(event));
+
+    const session = await captar.startSession({
+      budget: { maxSpendUsd: 2 },
+      policy: {
+        call: { blockedModels: ['gpt-4.1-mini'] },
+      },
+    });
+
+    const client = {
+      chat: {
+        completions: {
+          create: vi.fn(async () => ({
+            usage: { prompt_tokens: 100, completion_tokens: 50 },
+          })),
+        },
+      },
+    };
+
+    const openai = captar.wrapOpenAI(client, { session });
+
+    const wrappedPromise = openai.chat.completions.create({
+      model: 'gpt-4.1-mini',
+      messages: [{ role: 'user', content: 'hello' }],
+    });
+
+    await expect(wrappedPromise).rejects.toThrow();
+    expect(onPolicyViolation).toHaveBeenCalledOnce();
+    expect(onPolicyViolation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: session.trace.traceId,
+        reason: expect.stringContaining('gpt-4.1-mini'),
+        type: expect.any(String),
+      })
+    );
   });
 });

--- a/packages/ts/types/src/index.ts
+++ b/packages/ts/types/src/index.ts
@@ -33,7 +33,7 @@ export interface SessionPolicy {
   tool?: ToolPolicy;
 }
 
-export type PayloadRetentionMode = "redacted" | "raw" | "none";
+export type PayloadRetentionMode = 'redacted' | 'raw' | 'none';
 
 export type JsonPrimitive = string | number | boolean | null;
 
@@ -43,9 +43,9 @@ export interface JsonObject {
   [key: string]: JsonValue | undefined;
 }
 
-export type DatasetFileFormat = "json" | "jsonl" | "csv";
+export type DatasetFileFormat = 'json' | 'jsonl' | 'csv';
 
-export type DatasetSourceKind = "trace_export" | "file_import";
+export type DatasetSourceKind = 'trace_export' | 'file_import';
 
 export interface DatasetRowSource {
   kind: DatasetSourceKind;
@@ -92,9 +92,9 @@ export interface TraceDatasetExportInput {
   metadata?: JsonObject;
 }
 
-export type ManualEvalVerdict = "pass" | "fail";
+export type ManualEvalVerdict = 'pass' | 'fail';
 
-export type ManualEvalRunStatus = "in_progress" | "completed";
+export type ManualEvalRunStatus = 'in_progress' | 'completed';
 
 export interface ManualEvalCriterion {
   id: string;
@@ -218,9 +218,9 @@ export interface TraceContext {
   parentSpanId?: string;
 }
 
-export type TraceSpanKind = "session" | "request" | "tool";
+export type TraceSpanKind = 'session' | 'request' | 'tool';
 
-export type TraceSpanStatus = "running" | "completed" | "blocked" | "failed";
+export type TraceSpanStatus = 'running' | 'completed' | 'blocked' | 'failed';
 
 export interface TraceSpanSnapshot {
   id: string;
@@ -233,28 +233,23 @@ export interface TraceSpanSnapshot {
   attributes?: Metadata;
 }
 
-export type GuardrailCategory =
-  | "spend"
-  | "execution"
-  | "safety"
-  | "access"
-  | "workflow";
+export type GuardrailCategory = 'spend' | 'execution' | 'safety' | 'access' | 'workflow';
 
 export type CaptarEventType =
-  | "session.started"
-  | "session.closed"
-  | "request.started"
-  | "request.allowed"
-  | "request.blocked"
-  | "request.failed"
-  | "estimate.reserved"
-  | "provider.response"
-  | "spend.committed"
-  | "tool.started"
-  | "tool.blocked"
-  | "tool.completed"
-  | "tool.failed"
-  | "guardrail.violation";
+  | 'session.started'
+  | 'session.closed'
+  | 'request.started'
+  | 'request.allowed'
+  | 'request.blocked'
+  | 'request.failed'
+  | 'estimate.reserved'
+  | 'provider.response'
+  | 'spend.committed'
+  | 'tool.started'
+  | 'tool.blocked'
+  | 'tool.completed'
+  | 'tool.failed'
+  | 'guardrail.violation';
 
 export interface CaptarEvent<TData = Record<string, unknown>> {
   id: string;
@@ -354,16 +349,10 @@ export interface ToolHandle<TResult> {
 export interface TrackToolOptions<TArgs = unknown, TResult = unknown> {
   session: CaptarSession;
   args?: TArgs;
-  estimate?:
-    | number
-    | ((context: ToolEstimateContext<TArgs>) => Promise<number> | number);
-  actual?:
-    | number
-    | ((context: ToolActualContext<TResult>) => Promise<number> | number);
+  estimate?: number | ((context: ToolEstimateContext<TArgs>) => Promise<number> | number);
+  actual?: number | ((context: ToolActualContext<TResult>) => Promise<number> | number);
   policy?: ToolPolicy;
-  approval?:
-    | ((context: ToolApprovalContext<TArgs>) => Promise<boolean> | boolean)
-    | boolean;
+  approval?: ((context: ToolApprovalContext<TArgs>) => Promise<boolean> | boolean) | boolean;
 }
 
 export interface OpenAIWrapOptions {
@@ -398,9 +387,15 @@ export interface ControlPlaneOptions {
 
 export interface CaptarOptions {
   project: string;
-  pricing?: "builtin" | PricingEntry[];
+  pricing?: 'builtin' | PricingEntry[];
   pricingOverrides?: PricingOverride[];
   exporter?: HttpExporterOptions | Exporter;
   defaultPolicy?: SessionPolicy;
   controlPlane?: ControlPlaneOptions;
+  onBudgetExceeded?: (context: {
+    sessionId: string;
+    budgetUsd: number;
+    attemptedUsd: number;
+  }) => void;
+  onPolicyViolation?: (context: { sessionId: string; reason: string; type: string }) => void;
 }


### PR DESCRIPTION
## Summary
Closes #32. Stabilizes the @captar/sdk public API surface and adds budget/policy hooks.

## Changes
- Define `CaptarInstance` interface with JSDoc for all public methods (`createCaptar`, `startSession`, `wrapOpenAI`, `trackTool`, `flush`)
- Add `onBudgetExceeded` and `onPolicyViolation` optional hooks to `CaptarOptions`
- Wire hooks into `wrapOpenAI` catch block for blocked execution paths
- Export `BudgetExceededError` and `PolicyViolationError` from SDK public surface
- Fix `trackTool` return type to use `ToolHandle` (matching actual internal contract)

## Validation
- [x] All SDK tests pass (6/6)
- [x] TypeScript lint (`pnpm --filter @captar/sdk lint`) passes
- [x] New integration test validates `onPolicyViolation` fires on blocked model

## Risk Notes
- Hooks only fire for blocked executions (not generic failures)
- `onBudgetExceeded` context uses `getSummary().totalReservedUsd` for accuracy
- No breaking changes to existing API surface