### PR TITLE
docs: finalize marketing docs migration and deprecate standalone Mintlify (#35)

### DIFF
--- a/apps/docs/README.md
+++ b/apps/docs/README.md
@@ -1,30 +1,23 @@
-# Captar Docs
+# Captar Docs (Standalone Mintlify)
 
-This app now uses Mintlify instead of Fumadocs.
+**DEPRECATED** — The Captar docs have been migrated into `apps/marketing/content/docs/`. This standalone Mintlify app is retained for reference during the transition period.
 
-## Run locally
-
-From the repo root:
+Please use the marketing docs route instead:
 
 ```bash
-pnpm install
+pnpm --filter marketing dev
+# Docs at http://localhost:3001/docs
+```
+
+## Run locally (legacy)
+
+```bash
 pnpm --filter @captar/docs dev
 ```
 
-The docs site starts with `npx mint dev`, so you do not need a local Mintlify
-global install if you prefer the `pnpm` script.
-
-## Validate
+## Validate (legacy)
 
 ```bash
 pnpm --filter @captar/docs lint
 pnpm --filter @captar/docs build
 ```
-
-Both commands run `npx mint validate`.
-
-## Content structure
-
-- `docs.json` defines the Mintlify navigation and branding.
-- Root-level `*.mdx` files are the live docs pages.
-- The Captar logo is copied from the shared monorepo asset into `apps/docs/logo.png`.

--- a/apps/marketing/content/docs/changelog.mdx
+++ b/apps/marketing/content/docs/changelog.mdx
@@ -1,0 +1,34 @@
+---
+title: Changelog
+description: Recent changes across the Captar platform, SDK, and docs.
+---
+
+# Changelog
+
+## 2025-04-28
+
+### SDK
+
+- **Stabilized public API surface** — Added `CaptarInstance` interface with JSDoc for `createCaptar`, `startSession`, `wrapOpenAI`, `trackTool`, and `flush`.
+- **Hooks** — Added `onBudgetExceeded` and `onPolicyViolation` optional callbacks to `CaptarOptions`.
+- Fixed `trackTool` return type to expose `ToolHandle<TResult>` contract.
+
+### Platform
+
+- **Project dashboard** — New `/projects/[projectId]/dashboard` page with aggregated metrics, recent traces, and 30-day spend summary.
+
+### Developer Experience
+
+- Prettier formatting with `pnpm format`.
+- Husky pre-commit hooks via `lint-staged`.
+- `.editorconfig` and VS Code workspace settings.
+- Turborepo pipeline optimization with `globalEnv` and cache keys.
+- Added `CONTRIBUTING.md`.
+
+### CI/CD
+
+- GitHub Actions workflows for CI (`lint` + `test`), build, and release on version tags.
+
+---
+
+Older milestones are tracked in the project memory at `.ai/` and through GitHub issues.

--- a/apps/marketing/content/docs/reference/sdk-api.mdx
+++ b/apps/marketing/content/docs/reference/sdk-api.mdx
@@ -15,17 +15,35 @@ policy sync configuration.
 Use this once near app startup. It is the root object that everything else hangs
 off, so the configuration should stay small and obvious.
 
-```ts
-const captar = createCaptar({
-  project: "support-bot",
-  exporter: { url: process.env.CAPTAR_INGEST_URL! },
-  controlPlane: {
-    hookId: "hook_123",
-    syncPolicy: true,
-    baseUrl: "http://localhost:3000",
-  },
-});
-```
+## Options
+
+| Property            | Type                                           | Description                                                     |
+| ------------------- | ---------------------------------------------- | --------------------------------------------------------------- |
+| `project`           | `string`                                       | **Required.** Project slug for grouping traces.                 |
+| `exporter`          | `{ url: string; apiKey?: string } \| Exporter` | Optional batch exporter or HTTP endpoint.                       |
+| `controlPlane`      | `ControlPlaneOptions`                          | Optional hook ID and policy sync URL.                           |
+| `pricing`           | `"builtin" \| PricingEntry[]`                  | Pricing table to use for cost estimation.                       |
+| `defaultPolicy`     | `SessionPolicy`                                | Default policy merged into every session.                       |
+| `onBudgetExceeded`  | `(ctx) => void`                                | Optional hook called when a request exceeds the session budget. |
+| `onPolicyViolation` | `(ctx) => void`                                | Optional hook called when a request is blocked by policy.       |
+
+### Hooks
+
+`onBudgetExceeded` receives:
+
+| Property       | Type     | Description                                 |
+| -------------- | -------- | ------------------------------------------- |
+| `sessionId`    | `string` | The active session trace ID.                |
+| `budgetUsd`    | `number` | Total reserved USD at the point of failure. |
+| `attemptedUsd` | `number` | Estimated cost of the blocked request.      |
+
+`onPolicyViolation` receives:
+
+| Property    | Type     | Description                            |
+| ----------- | -------- | -------------------------------------- |
+| `sessionId` | `string` | The active session trace ID.           |
+| `reason`    | `string` | Human-readable violation reason.       |
+| `type`      | `string` | Violation category (e.g. `"blocked"`). |
 
 ## `startSession(options)`
 
@@ -46,6 +64,8 @@ Runs a tool inside the same runtime trace and applies tool policy before executi
 
 Use this for any external action that should show up alongside the model request
 that caused it.
+
+Returns a `ToolHandle` — call `.run(work)` to execute the wrapped work.
 
 ## `flush()`
 


### PR DESCRIPTION
## Summary
Closes #35. Finalizes the docs migration to marketing app and deprecates standalone Mintlify docs.

## Changes
- Update `apps/docs/README.md` with deprecation notice directing users to marketing docs
- Add `apps/marketing/content/docs/changelog.mdx` — project changelog covering v1 milestones
- Update `apps/marketing/content/docs/reference/sdk-api.mdx` with new hooks documentation (onBudgetExceeded, onPolicyViolation, ToolHandle)
- All docs content build passes: `pnpm --filter marketing build:content` + `typecheck`

## Validation
- [x] Marketing docs build and typecheck pass
- [x] Changelog page renders correctly
- [x] SDK API reference is accurate with current SDK surface

## Risk Notes
- `apps/docs` is NOT deleted — only marked deprecated for transition safety
- Standalone docs Mintlify config remains available if rollback needed