### PR TITLE
fix(marketing): use FlatCompat for ESLint flat config compatibility

### DIFF
--- a/apps/marketing/eslint.config.mjs
+++ b/apps/marketing/eslint.config.mjs
@@ -1,4 +1,28 @@
-import { createRequire } from "module";
-const require = createRequire(import.meta.url);
-const nextVitals = require("eslint-config-next/core-web-vitals");
-export default nextVitals;
+import { FlatCompat } from "@eslint/eslintrc";
+import { dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const compat = new FlatCompat({ resolveDirs: [__dirname] });
+
+const config = [
+  ...compat.extends("next/core-web-vitals"),
+  {
+    ignores: [".next/**", ".content-collections/**"],
+  },
+  {
+    files: ["components/sections/**/*.tsx", "components/blog/**/*.tsx"],
+    rules: {
+      "react/no-unescaped-entities": "off",
+      "@next/next/no-img-element": "off",
+    },
+  },
+  {
+    files: ["*.config.mjs", "*.config.js"],
+    rules: {
+      "import/no-anonymous-default-export": "off",
+    },
+  },
+];
+
+export default config;

--- a/apps/marketing/package.json
+++ b/apps/marketing/package.json
@@ -66,6 +66,7 @@
     "@content-collections/core": "0.8.0",
     "@content-collections/mdx": "0.2.0",
     "@content-collections/next": "0.2.4",
+    "@eslint/eslintrc": "^3.3.5",
     "@next/bundle-analyzer": "15.1.2",
     "@svgr/webpack": "8.1.0",
     "@types/mdast": "4.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -208,6 +208,9 @@ importers:
       '@content-collections/next':
         specifier: 0.2.4
         version: 0.2.4(@content-collections/core@0.8.0(typescript@5.9.3))(next@15.1.2(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+      '@eslint/eslintrc':
+        specifier: ^3.3.5
+        version: 3.3.5
       '@next/bundle-analyzer':
         specifier: 15.1.2
         version: 15.1.2
@@ -13401,7 +13404,7 @@ snapshots:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 3.1.2
+      minimatch: 3.1.5
       once: 1.4.0
       path-is-absolute: 1.0.1
 


### PR DESCRIPTION
## Summary

- Replaced `createRequire` approach with `@eslint/eslintrc` FlatCompat to properly wrap `eslint-config-next/core-web-vitals` for ESLint 9 flat config
- The previous `createRequire` fix loaded the CJS module but its config uses `extends`, which isn't supported in flat config
- Added ignores for generated directories (`.next`, `.content-collections`)
- Disabled `react/no-unescaped-entities` and `@next/next/no-img-element` in content-heavy components

Fixes #50