### PR TITLE
fix(platform): component bugs — Badge, HookCreate, auth, login

### DIFF
--- a/apps/platform/components/hook-create-dialog.tsx
+++ b/apps/platform/components/hook-create-dialog.tsx
@@ -1,9 +1,9 @@
-"use client";
+'use client';
 
-import { useState, useTransition } from "react";
-import { useRouter } from "next/navigation";
+import { useState, useTransition } from 'react';
+import { useRouter } from 'next/navigation';
 
-import { Button } from "./ui/button";
+import { Button } from './ui/button';
 import {
   Dialog,
   DialogContent,
@@ -11,14 +11,14 @@ import {
   DialogHeader,
   DialogTitle,
   DialogTrigger,
-} from "./ui/dialog";
-import { Input } from "./ui/input";
-import { Label } from "./ui/label";
+} from './ui/dialog';
+import { Input } from './ui/input';
+import { Label } from './ui/label';
 
 export function HookCreateDialog({ projectId }: { projectId: string }) {
   const router = useRouter();
-  const [name, setName] = useState("");
-  const [environment, setEnvironment] = useState("development");
+  const [name, setName] = useState('');
+  const [environment, setEnvironment] = useState('development');
   const [error, setError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
 
@@ -30,9 +30,7 @@ export function HookCreateDialog({ projectId }: { projectId: string }) {
       <DialogContent>
         <DialogHeader>
           <DialogTitle>New hook connection</DialogTitle>
-          <DialogDescription>
-            Create a hook ID your SDK can attach to calls.
-          </DialogDescription>
+          <DialogDescription>Create a hook ID your SDK can attach to calls.</DialogDescription>
         </DialogHeader>
         <div className="space-y-4">
           <div className="space-y-2">
@@ -59,25 +57,22 @@ export function HookCreateDialog({ projectId }: { projectId: string }) {
             onClick={() => {
               startTransition(async () => {
                 const response = await fetch(`/api/projects/${projectId}/hooks`, {
-                  method: "POST",
-                  headers: { "content-type": "application/json" },
+                  method: 'POST',
+                  headers: { 'content-type': 'application/json' },
                   body: JSON.stringify({ name, environment }),
                 });
+                const data = await response.json();
                 if (!response.ok) {
-                  const payload = (await response.json().catch(() => null)) as { error?: string } | null;
-                  setError(payload?.error ?? "Could not create hook. Please try again.");
+                  setError(data?.error ?? 'Could not create hook. Please try again.');
                   return;
                 }
                 setError(null);
-                const payload = (await response.json()) as {
-                  hook: { publicId: string };
-                };
-                router.push(`/hooks/${payload.hook.publicId}`);
+                router.push(`/hooks/${data.hook.publicId}`);
                 router.refresh();
               });
             }}
           >
-            {isPending ? "Creating..." : "Create hook"}
+            {isPending ? 'Creating...' : 'Create hook'}
           </Button>
         </div>
       </DialogContent>

--- a/apps/platform/components/hook-create-dialog.tsx
+++ b/apps/platform/components/hook-create-dialog.tsx
@@ -19,6 +19,7 @@ export function HookCreateDialog({ projectId }: { projectId: string }) {
   const router = useRouter();
   const [name, setName] = useState("");
   const [environment, setEnvironment] = useState("development");
+  const [error, setError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
 
   return (
@@ -52,6 +53,7 @@ export function HookCreateDialog({ projectId }: { projectId: string }) {
               placeholder="development"
             />
           </div>
+          {error && <p className="text-sm text-red-500">{error}</p>}
           <Button
             disabled={isPending || !name.trim()}
             onClick={() => {
@@ -62,8 +64,11 @@ export function HookCreateDialog({ projectId }: { projectId: string }) {
                   body: JSON.stringify({ name, environment }),
                 });
                 if (!response.ok) {
+                  const payload = (await response.json().catch(() => null)) as { error?: string } | null;
+                  setError(payload?.error ?? "Could not create hook. Please try again.");
                   return;
                 }
+                setError(null);
                 const payload = (await response.json()) as {
                   hook: { publicId: string };
                 };

--- a/apps/platform/components/ui/badge.tsx
+++ b/apps/platform/components/ui/badge.tsx
@@ -1,11 +1,26 @@
 import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
 
 import { cn } from '../../lib/utils';
 
-export function Badge({ className, children, ...props }: React.HTMLAttributes<HTMLSpanElement>) {
-  return (
-    <span className={cn(badgeVariants(), className)} {...props}>
-      {children}
-    </span>
-  );
+const badgeVariants = cva('inline-flex items-center rounded-md px-2 py-0.5 text-xs font-medium', {
+  variants: {
+    variant: {
+      default: 'bg-cyan-400/15 text-cyan-400',
+      secondary: 'bg-slate-800 text-slate-300',
+      outline: 'border border-slate-700 text-slate-300',
+    },
+  },
+  defaultVariants: {
+    variant: 'default',
+  },
+});
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLSpanElement>, VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return <span className={cn(badgeVariants({ variant }), className)} {...props} />;
 }
+
+export { Badge, badgeVariants };


### PR DESCRIPTION
## Summary

Fixes #46

4 component bugs addressed:

1. **Badge className** — Added proper `cva`-based `badgeVariants` definition (was undefined), export `BadgeProps` interface, pass `variant` + `className` through `cn()`, spread remaining props
2. **HookCreateDialog error feedback** — Added `error` state, parse error from API response on failure, display error message to user; clear on success
3. **Auth secret** — Already fixed in prior commit (dev-only fallback)
4. **Login defaults** — Already fixed in prior commit (dev-gated, autoComplete attributes)

## Files changed

- `apps/platform/components/ui/badge.tsx` — cva variants, proper exports, className pass-through
- `apps/platform/components/hook-create-dialog.tsx` — error state + user-facing error display

## Verification

`pnpm --filter @captar/platform build` passes ✅