### PR TITLE
fix(platform): remove vestigial Pages Router, add @types/react

### DIFF
--- a/apps/platform/components/ui/badge.tsx
+++ b/apps/platform/components/ui/badge.tsx
@@ -1,11 +1,26 @@
 import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
 
 import { cn } from '../../lib/utils';
 
-export function Badge({ className, children, ...props }: React.HTMLAttributes<HTMLSpanElement>) {
-  return (
-    <span className={cn(badgeVariants(), className)} {...props}>
-      {children}
-    </span>
-  );
+const badgeVariants = cva('inline-flex items-center rounded-md px-2 py-0.5 text-xs font-medium', {
+  variants: {
+    variant: {
+      default: 'bg-cyan-400/15 text-cyan-400',
+      secondary: 'bg-slate-800 text-slate-300',
+      outline: 'border border-slate-700 text-slate-300',
+    },
+  },
+  defaultVariants: {
+    variant: 'default',
+  },
+});
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLSpanElement>, VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return <span className={cn(badgeVariants({ variant }), className)} {...props} />;
 }
+
+export { Badge, badgeVariants };


### PR DESCRIPTION
## Summary
Fixes #45

- Pages Router directory (`pages/`) was already removed in a prior change
- `@types/react` and `@types/react-dom` were already added as devDependencies
- Fixes `badge.tsx` build error: component referenced `badgeVariants()` without definition — added proper `cva`-based variant system with default, secondary, and outline variants

The original #45 issues (vestigial pages router + missing type deps) are already resolved on `main`. This PR fixes the remaining build breakage caused by the undefined `badgeVariants` in `badge.tsx`, which prevented verification.

## Files changed
- `apps/platform/components/ui/badge.tsx` — added `cva` variants, typed `BadgeProps`, exported `badgeVariants`

## Verification
- `pnpm --filter @captar/platform build` ✅
- `pnpm --filter @captar/platform lint` ✅