### PR TITLE
feat(platform): add loading/error/not-found pages

### DIFF
--- a/apps/platform/app/error.tsx
+++ b/apps/platform/app/error.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+export default function RootError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <div className="flex h-screen flex-col items-center justify-center gap-4">
+      <h2 className="text-xl font-semibold text-slate-100">Something went wrong</h2>
+      <p className="text-sm text-slate-400">{error.message}</p>
+      <button
+        onClick={reset}
+        className="rounded-md bg-cyan-600 px-4 py-2 text-sm font-medium text-white hover:bg-cyan-500"
+      >
+        Try again
+      </button>
+    </div>
+  );
+}

--- a/apps/platform/app/hooks/[hookId]/loading.tsx
+++ b/apps/platform/app/hooks/[hookId]/loading.tsx
@@ -1,0 +1,8 @@
+export default function DetailLoading() {
+  return (
+    <div className="space-y-4 p-6">
+      <div className="h-8 w-64 animate-pulse rounded bg-slate-800" />
+      <div className="h-48 animate-pulse rounded-lg border border-slate-800 bg-slate-900" />
+    </div>
+  );
+}

--- a/apps/platform/app/loading.tsx
+++ b/apps/platform/app/loading.tsx
@@ -1,0 +1,7 @@
+export default function RootLoading() {
+  return (
+    <div className="flex h-screen items-center justify-center">
+      <div className="h-8 w-8 animate-spin rounded-full border-4 border-slate-600 border-t-cyan-400" />
+    </div>
+  );
+}

--- a/apps/platform/app/not-found.tsx
+++ b/apps/platform/app/not-found.tsx
@@ -1,0 +1,13 @@
+import Link from 'next/link';
+
+export default function NotFound() {
+  return (
+    <div className="flex h-screen flex-col items-center justify-center gap-4">
+      <h2 className="text-2xl font-bold text-slate-100">404 — Page not found</h2>
+      <p className="text-sm text-slate-400">The page you are looking for does not exist.</p>
+      <Link href="/projects" className="text-cyan-400 hover:underline">
+        Go to projects
+      </Link>
+    </div>
+  );
+}

--- a/apps/platform/app/projects/[projectId]/dashboard/loading.tsx
+++ b/apps/platform/app/projects/[projectId]/dashboard/loading.tsx
@@ -1,0 +1,16 @@
+export default function DashboardLoading() {
+  return (
+    <div className="space-y-4 p-6">
+      <div className="h-8 w-64 animate-pulse rounded bg-slate-800" />
+      <div className="grid gap-4 md:grid-cols-3">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div
+            key={i}
+            className="h-24 animate-pulse rounded-lg border border-slate-800 bg-slate-900"
+          />
+        ))}
+      </div>
+      <div className="h-64 animate-pulse rounded-lg border border-slate-800 bg-slate-900" />
+    </div>
+  );
+}

--- a/apps/platform/app/projects/[projectId]/datasets/[datasetId]/loading.tsx
+++ b/apps/platform/app/projects/[projectId]/datasets/[datasetId]/loading.tsx
@@ -1,0 +1,8 @@
+export default function DetailLoading() {
+  return (
+    <div className="space-y-4 p-6">
+      <div className="h-8 w-64 animate-pulse rounded bg-slate-800" />
+      <div className="h-48 animate-pulse rounded-lg border border-slate-800 bg-slate-900" />
+    </div>
+  );
+}

--- a/apps/platform/app/projects/[projectId]/datasets/error.tsx
+++ b/apps/platform/app/projects/[projectId]/datasets/error.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+export default function SegmentError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <div className="flex min-h-[50vh] flex-col items-center justify-center gap-4">
+      <h2 className="text-lg font-semibold text-slate-100">Something went wrong</h2>
+      <button
+        onClick={reset}
+        className="rounded-md bg-cyan-600 px-4 py-2 text-sm font-medium text-white hover:bg-cyan-500"
+      >
+        Try again
+      </button>
+    </div>
+  );
+}

--- a/apps/platform/app/projects/[projectId]/datasets/loading.tsx
+++ b/apps/platform/app/projects/[projectId]/datasets/loading.tsx
@@ -1,0 +1,15 @@
+export default function ListLoading() {
+  return (
+    <div className="space-y-4 p-6">
+      <div className="h-8 w-48 animate-pulse rounded bg-slate-800" />
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div
+            key={i}
+            className="h-32 animate-pulse rounded-lg border border-slate-800 bg-slate-900"
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/platform/app/projects/[projectId]/error.tsx
+++ b/apps/platform/app/projects/[projectId]/error.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+export default function SegmentError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <div className="flex min-h-[50vh] flex-col items-center justify-center gap-4">
+      <h2 className="text-lg font-semibold text-slate-100">Something went wrong</h2>
+      <button
+        onClick={reset}
+        className="rounded-md bg-cyan-600 px-4 py-2 text-sm font-medium text-white hover:bg-cyan-500"
+      >
+        Try again
+      </button>
+    </div>
+  );
+}

--- a/apps/platform/app/projects/[projectId]/evals/[evalId]/loading.tsx
+++ b/apps/platform/app/projects/[projectId]/evals/[evalId]/loading.tsx
@@ -1,0 +1,8 @@
+export default function DetailLoading() {
+  return (
+    <div className="space-y-4 p-6">
+      <div className="h-8 w-64 animate-pulse rounded bg-slate-800" />
+      <div className="h-48 animate-pulse rounded-lg border border-slate-800 bg-slate-900" />
+    </div>
+  );
+}

--- a/apps/platform/app/projects/[projectId]/evals/[evalId]/runs/[runId]/loading.tsx
+++ b/apps/platform/app/projects/[projectId]/evals/[evalId]/runs/[runId]/loading.tsx
@@ -1,0 +1,8 @@
+export default function DetailLoading() {
+  return (
+    <div className="space-y-4 p-6">
+      <div className="h-8 w-64 animate-pulse rounded bg-slate-800" />
+      <div className="h-48 animate-pulse rounded-lg border border-slate-800 bg-slate-900" />
+    </div>
+  );
+}

--- a/apps/platform/app/projects/[projectId]/evals/error.tsx
+++ b/apps/platform/app/projects/[projectId]/evals/error.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+export default function SegmentError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <div className="flex min-h-[50vh] flex-col items-center justify-center gap-4">
+      <h2 className="text-lg font-semibold text-slate-100">Something went wrong</h2>
+      <button
+        onClick={reset}
+        className="rounded-md bg-cyan-600 px-4 py-2 text-sm font-medium text-white hover:bg-cyan-500"
+      >
+        Try again
+      </button>
+    </div>
+  );
+}

--- a/apps/platform/app/projects/[projectId]/evals/loading.tsx
+++ b/apps/platform/app/projects/[projectId]/evals/loading.tsx
@@ -1,0 +1,15 @@
+export default function ListLoading() {
+  return (
+    <div className="space-y-4 p-6">
+      <div className="h-8 w-48 animate-pulse rounded bg-slate-800" />
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div
+            key={i}
+            className="h-32 animate-pulse rounded-lg border border-slate-800 bg-slate-900"
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/platform/app/projects/[projectId]/loading.tsx
+++ b/apps/platform/app/projects/[projectId]/loading.tsx
@@ -1,0 +1,8 @@
+export default function DetailLoading() {
+  return (
+    <div className="space-y-4 p-6">
+      <div className="h-8 w-64 animate-pulse rounded bg-slate-800" />
+      <div className="h-48 animate-pulse rounded-lg border border-slate-800 bg-slate-900" />
+    </div>
+  );
+}

--- a/apps/platform/app/projects/loading.tsx
+++ b/apps/platform/app/projects/loading.tsx
@@ -1,0 +1,15 @@
+export default function ListLoading() {
+  return (
+    <div className="space-y-4 p-6">
+      <div className="h-8 w-48 animate-pulse rounded bg-slate-800" />
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div
+            key={i}
+            className="h-32 animate-pulse rounded-lg border border-slate-800 bg-slate-900"
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/platform/app/traces/[traceId]/loading.tsx
+++ b/apps/platform/app/traces/[traceId]/loading.tsx
@@ -1,0 +1,8 @@
+export default function DetailLoading() {
+  return (
+    <div className="space-y-4 p-6">
+      <div className="h-8 w-64 animate-pulse rounded bg-slate-800" />
+      <div className="h-48 animate-pulse rounded-lg border border-slate-800 bg-slate-900" />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Add root `loading.tsx` (spinner), `error.tsx` (error boundary), and `not-found.tsx` (custom 404) to match dark theme
- Add segment `loading.tsx` for all route patterns: list (skeleton cards), detail (skeleton header + content), dashboard (stats + chart)
- Add segment `error.tsx` for project, datasets, and evals routes with "Try again" reset button

Fixes #47