### PR TITLE
refactor(platform): deduplicate shared components and utilities

### DIFF
--- a/apps/platform/app/login/page.tsx
+++ b/apps/platform/app/login/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from 'next/navigation';
 
 import { signIn, auth } from '../../auth';
+import { appGradient } from '../../lib/utils';
 import { Button } from '../../components/ui/button';
 import {
   Card,
@@ -19,7 +20,7 @@ export default async function LoginPage() {
   }
 
   return (
-    <main className="flex min-h-screen items-center justify-center bg-[radial-gradient(circle_at_top_left,_rgba(34,211,238,0.14),_transparent_28%),linear-gradient(180deg,_#020617_0%,_#0f172a_100%)] p-6">
+    <main className={`flex min-h-screen items-center justify-center ${appGradient} p-6`}>
       <Card className="w-full max-w-md">
         <CardHeader>
           <CardTitle>Sign in to Captar</CardTitle>

--- a/apps/platform/app/projects/[projectId]/datasets/[datasetId]/page.tsx
+++ b/apps/platform/app/projects/[projectId]/datasets/[datasetId]/page.tsx
@@ -1,18 +1,36 @@
-import Link from "next/link";
-import { notFound } from "next/navigation";
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
 
-import type { JsonValue } from "@captar/types";
+import { AppShell } from '../../../../../components/app-shell';
+import { DatasetImportForm } from '../../../../../components/dataset-import-form';
+import { ManualEvalCreateForm } from '../../../../../components/manual-eval-create-form';
+import { MetricCard } from '../../../../../components/metric-card';
+import { PayloadCard } from '../../../../../components/payload-card';
+import { Badge } from '../../../../../components/ui/badge';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '../../../../../components/ui/card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '../../../../../components/ui/table';
+import { requireUser } from '../../../../../lib/auth-guard';
+import {
+  getProjectById,
+  getProjectDatasetById,
+  listDatasetManualEvals,
+} from '../../../../../lib/platform';
+import { formatTimestamp } from '../../../../../lib/utils';
 
-import { AppShell } from "../../../../../components/app-shell";
-import { DatasetImportForm } from "../../../../../components/dataset-import-form";
-import { ManualEvalCreateForm } from "../../../../../components/manual-eval-create-form";
-import { Badge } from "../../../../../components/ui/badge";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../../../../../components/ui/card";
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../../../../../components/ui/table";
-import { requireUser } from "../../../../../lib/auth-guard";
-import { getProjectById, getProjectDatasetById, listDatasetManualEvals } from "../../../../../lib/platform";
-
-export const dynamic = "force-dynamic";
+export const dynamic = 'force-dynamic';
 
 export default async function DatasetDetailPage({
   params,
@@ -43,7 +61,7 @@ export default async function DatasetDetailPage({
                 <Badge>{dataset.rowCount} rows</Badge>
               </div>
               <CardDescription>
-                Dataset in project{" "}
+                Dataset in project{' '}
                 <Link
                   className="text-cyan-300 hover:text-cyan-200"
                   href={`/projects/${project.id}`}
@@ -52,7 +70,7 @@ export default async function DatasetDetailPage({
                 </Link>
               </CardDescription>
               <p className="text-sm text-slate-400">
-                {dataset.description ?? "No description yet."}
+                {dataset.description ?? 'No description yet.'}
               </p>
               <p className="text-sm text-slate-500">
                 {manualEvals.length} manual eval(s) currently use this dataset.
@@ -116,7 +134,7 @@ export default async function DatasetDetailPage({
                             {manualEval.name}
                           </Link>
                           <p className="mt-1 text-sm text-slate-400">
-                            {manualEval.description ?? "No description yet."}
+                            {manualEval.description ?? 'No description yet.'}
                           </p>
                         </div>
                         <Badge>{manualEval.runCount} runs</Badge>
@@ -141,7 +159,8 @@ export default async function DatasetDetailPage({
               <CardHeader>
                 <CardTitle>Dataset rows</CardTitle>
                 <CardDescription>
-                  Rows stay append-only in v1 so trace exports, imports, and manual eval runs remain auditable.
+                  Rows stay append-only in v1 so trace exports, imports, and manual eval runs remain
+                  auditable.
                 </CardDescription>
               </CardHeader>
               <CardContent>
@@ -161,14 +180,14 @@ export default async function DatasetDetailPage({
                         <TableRow key={row.id}>
                           <TableCell className="font-mono text-xs">{row.position}</TableCell>
                           <TableCell>
-                            <RowPayload value={row.input} />
+                            <PayloadCard label="Input" data={row.input} />
                           </TableCell>
                           <TableCell>
-                            <RowPayload value={row.output ?? null} emptyLabel="No output" />
+                            <PayloadCard label="Output" data={row.output ?? null} />
                           </TableCell>
                           <TableCell>
                             <div className="space-y-2 text-sm text-slate-300">
-                              <Badge>{row.source?.kind ?? "file_import"}</Badge>
+                              <Badge>{row.source?.kind ?? 'file_import'}</Badge>
                               {row.source?.traceId ? (
                                 <Link
                                   className="block text-cyan-300 hover:text-cyan-200"
@@ -188,8 +207,8 @@ export default async function DatasetDetailPage({
                           </TableCell>
                           <TableCell>
                             <div className="space-y-2 text-sm text-slate-300">
-                              <p>Input: {row.source?.inputRetentionMode ?? "n/a"}</p>
-                              <p>Output: {row.source?.outputRetentionMode ?? "n/a"}</p>
+                              <p>Input: {row.source?.inputRetentionMode ?? 'n/a'}</p>
+                              <p>Output: {row.source?.outputRetentionMode ?? 'n/a'}</p>
                             </div>
                           </TableCell>
                         </TableRow>
@@ -210,13 +229,7 @@ export default async function DatasetDetailPage({
   );
 }
 
-function DatasetExportLink({
-  href,
-  label,
-}: {
-  href: string;
-  label: string;
-}) {
+function DatasetExportLink({ href, label }: { href: string; label: string }) {
   return (
     <a
       className="inline-flex items-center rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 transition hover:border-cyan-400/40 hover:text-cyan-200"
@@ -225,35 +238,4 @@ function DatasetExportLink({
       {label}
     </a>
   );
-}
-
-function MetricCard({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="rounded-xl border border-slate-800 bg-slate-900/60 p-4">
-      <p className="text-sm text-slate-400">{label}</p>
-      <p className="text-lg font-semibold">{value}</p>
-    </div>
-  );
-}
-
-function RowPayload({
-  value,
-  emptyLabel = "No value",
-}: {
-  value: JsonValue | null;
-  emptyLabel?: string;
-}) {
-  if (value == null) {
-    return <p className="text-sm text-slate-500">{emptyLabel}</p>;
-  }
-
-  return (
-    <pre className="max-w-[320px] overflow-x-auto whitespace-pre-wrap rounded-lg border border-slate-800 bg-slate-950 p-3 text-xs text-slate-200">
-      {typeof value === "string" ? value : JSON.stringify(value, null, 2)}
-    </pre>
-  );
-}
-
-function formatTimestamp(value: string) {
-  return new Date(value).toISOString();
 }

--- a/apps/platform/app/projects/[projectId]/datasets/page.tsx
+++ b/apps/platform/app/projects/[projectId]/datasets/page.tsx
@@ -1,15 +1,29 @@
-import Link from "next/link";
-import { notFound } from "next/navigation";
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
 
-import { AppShell } from "../../../../components/app-shell";
-import { DatasetCreateForm } from "../../../../components/dataset-create-form";
-import { Badge } from "../../../../components/ui/badge";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../../../../components/ui/card";
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../../../../components/ui/table";
-import { requireUser } from "../../../../lib/auth-guard";
-import { getProjectById, listProjectDatasets } from "../../../../lib/platform";
+import { AppShell } from '../../../../components/app-shell';
+import { DatasetCreateForm } from '../../../../components/dataset-create-form';
+import { Badge } from '../../../../components/ui/badge';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '../../../../components/ui/card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '../../../../components/ui/table';
+import { requireUser } from '../../../../lib/auth-guard';
+import { formatTimestamp } from '../../../../lib/utils';
+import { getProjectById, listProjectDatasets } from '../../../../lib/platform';
 
-export const dynamic = "force-dynamic";
+export const dynamic = 'force-dynamic';
 
 export default async function ProjectDatasetsPage({
   params,
@@ -41,7 +55,7 @@ export default async function ProjectDatasetsPage({
                   <Badge>{project._count.datasets}</Badge>
                 </div>
                 <CardDescription>
-                  Reusable rows exported from traces or appended from files for project{" "}
+                  Reusable rows exported from traces or appended from files for project{' '}
                   <span className="font-medium text-slate-200">{project.name}</span>.
                 </CardDescription>
               </div>
@@ -75,7 +89,7 @@ export default async function ProjectDatasetsPage({
                           </Link>
                         </TableCell>
                         <TableCell className="text-slate-300">
-                          {dataset.description ?? "No description"}
+                          {dataset.description ?? 'No description'}
                         </TableCell>
                         <TableCell>{dataset.rowCount}</TableCell>
                         <TableCell>{formatTimestamp(dataset.updatedAt)}</TableCell>
@@ -94,8 +108,4 @@ export default async function ProjectDatasetsPage({
       </div>
     </AppShell>
   );
-}
-
-function formatTimestamp(value: string) {
-  return new Date(value).toISOString();
 }

--- a/apps/platform/app/projects/[projectId]/evals/[evalId]/page.tsx
+++ b/apps/platform/app/projects/[projectId]/evals/[evalId]/page.tsx
@@ -1,15 +1,30 @@
-import Link from "next/link";
-import { notFound } from "next/navigation";
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
 
-import { AppShell } from "../../../../../components/app-shell";
-import { ManualEvalStartRunButton } from "../../../../../components/manual-eval-start-run-button";
-import { Badge } from "../../../../../components/ui/badge";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../../../../../components/ui/card";
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../../../../../components/ui/table";
-import { requireUser } from "../../../../../lib/auth-guard";
-import { getProjectManualEvalById } from "../../../../../lib/platform";
+import { AppShell } from '../../../../../components/app-shell';
+import { ManualEvalStartRunButton } from '../../../../../components/manual-eval-start-run-button';
+import { MetricCard } from '../../../../../components/metric-card';
+import { Badge } from '../../../../../components/ui/badge';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '../../../../../components/ui/card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '../../../../../components/ui/table';
+import { requireUser } from '../../../../../lib/auth-guard';
+import { getProjectManualEvalById } from '../../../../../lib/platform';
+import { formatTimestamp } from '../../../../../lib/utils';
 
-export const dynamic = "force-dynamic";
+export const dynamic = 'force-dynamic';
 
 export default async function ManualEvalDetailPage({
   params,
@@ -37,7 +52,7 @@ export default async function ManualEvalDetailPage({
                 <Badge>{manualEval.runCount} runs</Badge>
               </div>
               <CardDescription>
-                Manual eval backed by dataset{" "}
+                Manual eval backed by dataset{' '}
                 <Link
                   className="text-cyan-300 hover:text-cyan-200"
                   href={`/projects/${projectId}/datasets/${dataset.id}`}
@@ -46,7 +61,7 @@ export default async function ManualEvalDetailPage({
                 </Link>
               </CardDescription>
               <p className="text-sm text-slate-400">
-                {manualEval.description ?? "No description yet."}
+                {manualEval.description ?? 'No description yet.'}
               </p>
             </div>
             <div className="space-y-2">
@@ -72,7 +87,7 @@ export default async function ManualEvalDetailPage({
               value={
                 manualEval.metrics.overallAverageScore != null
                   ? manualEval.metrics.overallAverageScore.toFixed(3)
-                  : "n/a"
+                  : 'n/a'
               }
             />
           </CardContent>
@@ -95,7 +110,7 @@ export default async function ManualEvalDetailPage({
 
               {manualEval.criteria.map((criterion) => {
                 const metric = manualEval.metrics.criterionAverages.find(
-                  (entry) => entry.criterionId === criterion.id,
+                  (entry) => entry.criterionId === criterion.id
                 );
 
                 return (
@@ -107,13 +122,14 @@ export default async function ManualEvalDetailPage({
                       <div>
                         <p className="font-medium">{criterion.label}</p>
                         <p className="mt-1 text-sm text-slate-400">
-                          {criterion.description ?? "No description provided."}
+                          {criterion.description ?? 'No description provided.'}
                         </p>
                       </div>
                       <div className="text-right text-sm text-slate-300">
                         <p>Weight {criterion.weight}</p>
                         <p>
-                          Avg {metric?.averageScore != null ? metric.averageScore.toFixed(3) : "n/a"}
+                          Avg{' '}
+                          {metric?.averageScore != null ? metric.averageScore.toFixed(3) : 'n/a'}
                         </p>
                       </div>
                     </div>
@@ -156,7 +172,7 @@ export default async function ManualEvalDetailPage({
                           {run.metrics.reviewedRows}/{run.metrics.totalRows}
                         </TableCell>
                         <TableCell>{(run.metrics.passRate * 100).toFixed(1)}%</TableCell>
-                        <TableCell>{new Date(run.createdAt).toISOString()}</TableCell>
+                        <TableCell>{formatTimestamp(run.createdAt)}</TableCell>
                       </TableRow>
                     ))}
                   </TableBody>
@@ -171,14 +187,5 @@ export default async function ManualEvalDetailPage({
         </div>
       </div>
     </AppShell>
-  );
-}
-
-function MetricCard({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="rounded-xl border border-slate-800 bg-slate-900/60 p-4">
-      <p className="text-sm text-slate-400">{label}</p>
-      <p className="text-xl font-semibold">{value}</p>
-    </div>
   );
 }

--- a/apps/platform/app/projects/[projectId]/evals/[evalId]/runs/[runId]/page.tsx
+++ b/apps/platform/app/projects/[projectId]/evals/[evalId]/runs/[runId]/page.tsx
@@ -1,13 +1,20 @@
-import { notFound } from "next/navigation";
+import { notFound } from 'next/navigation';
 
-import { AppShell } from "../../../../../../../components/app-shell";
-import { ManualEvalRunReviewer } from "../../../../../../../components/manual-eval-run-reviewer";
-import { Badge } from "../../../../../../../components/ui/badge";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../../../../../../../components/ui/card";
-import { requireUser } from "../../../../../../../lib/auth-guard";
-import { getProjectManualEvalRunById } from "../../../../../../../lib/platform";
+import { AppShell } from '../../../../../../../components/app-shell';
+import { ManualEvalRunReviewer } from '../../../../../../../components/manual-eval-run-reviewer';
+import { Badge } from '../../../../../../../components/ui/badge';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '../../../../../../../components/ui/card';
+import { requireUser } from '../../../../../../../lib/auth-guard';
+import { getProjectManualEvalRunById } from '../../../../../../../lib/platform';
+import { formatTimestamp } from '../../../../../../../lib/utils';
 
-export const dynamic = "force-dynamic";
+export const dynamic = 'force-dynamic';
 
 export default async function ManualEvalRunPage({
   params,
@@ -33,17 +40,15 @@ export default async function ManualEvalRunPage({
                 <Badge>{payload.run.status}</Badge>
               </div>
               <CardDescription>
-                Reviewer workspace for dataset{" "}
+                Reviewer workspace for dataset{' '}
                 <span className="font-medium text-slate-200">{payload.dataset.name}</span>
               </CardDescription>
             </div>
             <div className="text-right text-sm text-slate-400">
-              <p>Started {new Date(payload.run.createdAt).toISOString()}</p>
+              <p>Started {formatTimestamp(payload.run.createdAt)}</p>
               <p>
-                Completed{" "}
-                {payload.run.completedAt
-                  ? new Date(payload.run.completedAt).toISOString()
-                  : "in progress"}
+                Completed{' '}
+                {payload.run.completedAt ? formatTimestamp(payload.run.completedAt) : 'in progress'}
               </p>
             </div>
           </CardHeader>

--- a/apps/platform/app/projects/[projectId]/evals/page.tsx
+++ b/apps/platform/app/projects/[projectId]/evals/page.tsx
@@ -1,14 +1,28 @@
-import Link from "next/link";
-import { notFound } from "next/navigation";
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
 
-import { AppShell } from "../../../../components/app-shell";
-import { Badge } from "../../../../components/ui/badge";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../../../../components/ui/card";
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../../../../components/ui/table";
-import { requireUser } from "../../../../lib/auth-guard";
-import { getProjectById, listProjectManualEvals } from "../../../../lib/platform";
+import { AppShell } from '../../../../components/app-shell';
+import { Badge } from '../../../../components/ui/badge';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '../../../../components/ui/card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '../../../../components/ui/table';
+import { requireUser } from '../../../../lib/auth-guard';
+import { formatTimestamp } from '../../../../lib/utils';
+import { getProjectById, listProjectManualEvals } from '../../../../lib/platform';
 
-export const dynamic = "force-dynamic";
+export const dynamic = 'force-dynamic';
 
 export default async function ProjectManualEvalsPage({
   params,
@@ -37,7 +51,7 @@ export default async function ProjectManualEvalsPage({
                 <Badge>{project._count.manualEvals}</Badge>
               </div>
               <CardDescription>
-                Offline reviewer workflows for project{" "}
+                Offline reviewer workflows for project{' '}
                 <span className="font-medium text-slate-200">{project.name}</span>.
               </CardDescription>
             </div>
@@ -85,7 +99,7 @@ export default async function ProjectManualEvalsPage({
                         {manualEval.metrics.reviewedRows}/{manualEval.metrics.totalRows}
                       </TableCell>
                       <TableCell>{(manualEval.metrics.passRate * 100).toFixed(1)}%</TableCell>
-                      <TableCell>{new Date(manualEval.updatedAt).toISOString()}</TableCell>
+                      <TableCell>{formatTimestamp(manualEval.updatedAt)}</TableCell>
                     </TableRow>
                   ))}
                 </TableBody>

--- a/apps/platform/app/traces/[traceId]/page.tsx
+++ b/apps/platform/app/traces/[traceId]/page.tsx
@@ -1,23 +1,34 @@
-import { notFound } from "next/navigation";
+import { notFound } from 'next/navigation';
 
-import { AppShell } from "../../../components/app-shell";
-import { TraceDatasetExportCard } from "../../../components/trace-dataset-export-card";
-import { TraceAutoRefresh } from "../../../components/trace-auto-refresh";
-import { Badge } from "../../../components/ui/badge";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../../../components/ui/card";
-import { Separator } from "../../../components/ui/separator";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "../../../components/ui/tabs";
-import { requireUser } from "../../../lib/auth-guard";
-import { buildTraceSpanTree, buildTraceTimeline, flattenTraceSpanTree, summarizeTraceFromSpans, type TraceSpanNode, type TraceTimelineItem } from "../../../lib/trace-spans";
-import { getTraceById, listProjectDatasets } from "../../../lib/platform";
+import { AppShell } from '../../../components/app-shell';
+import { MetricCard } from '../../../components/metric-card';
+import { TraceDatasetExportCard } from '../../../components/trace-dataset-export-card';
+import { TraceAutoRefresh } from '../../../components/trace-auto-refresh';
+import { Badge } from '../../../components/ui/badge';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '../../../components/ui/card';
+import { Separator } from '../../../components/ui/separator';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '../../../components/ui/tabs';
+import { requireUser } from '../../../lib/auth-guard';
+import { cn, formatTimestamp } from '../../../lib/utils';
+import {
+  buildTraceSpanTree,
+  buildTraceTimeline,
+  flattenTraceSpanTree,
+  summarizeTraceFromSpans,
+  type TraceSpanNode,
+  type TraceTimelineItem,
+} from '../../../lib/trace-spans';
+import { getTraceById, listProjectDatasets } from '../../../lib/platform';
 
-export const dynamic = "force-dynamic";
+export const dynamic = 'force-dynamic';
 
-export default async function TracePage({
-  params,
-}: {
-  params: Promise<{ traceId: string }>;
-}) {
+export default async function TracePage({ params }: { params: Promise<{ traceId: string }> }) {
   const user = await requireUser();
   const { traceId } = await params;
   const trace = await getTraceById(traceId, user.id);
@@ -34,14 +45,14 @@ export default async function TracePage({
   const timeline = buildTraceTimeline(trace.spans);
   const timelineWindowMs = Math.max(
     1,
-    ...timeline.map((item) => item.offsetMs + (item.durationMs ?? 0)),
+    ...timeline.map((item) => item.offsetMs + (item.durationMs ?? 0))
   );
   const currentStatus = summary.status ?? trace.status;
 
   return (
     <AppShell userName={user.email}>
       <div className="grid gap-6">
-        <TraceAutoRefresh active={currentStatus === "RUNNING"} />
+        <TraceAutoRefresh active={currentStatus === 'RUNNING'} />
 
         <Card>
           <CardHeader>
@@ -52,16 +63,23 @@ export default async function TracePage({
                   <Badge>{currentStatus}</Badge>
                 </div>
                 <CardDescription>
-                  Trace for hook <span className="font-mono text-xs text-cyan-300">{trace.hook.publicId}</span>
+                  Trace for hook{' '}
+                  <span className="font-mono text-xs text-cyan-300">{trace.hook.publicId}</span>
                 </CardDescription>
                 <p className="text-sm text-slate-400">
-                  Latest model: {trace.model ?? "unknown"} · Provider: {trace.provider ?? "unknown"}
+                  Latest model: {trace.model ?? 'unknown'} · Provider: {trace.provider ?? 'unknown'}
                 </p>
               </div>
               <div className="text-sm text-slate-400">
-                <p>Session: <span className="font-mono text-xs">{trace.llmSession.externalSessionId}</span></p>
+                <p>
+                  Session:{' '}
+                  <span className="font-mono text-xs">{trace.llmSession.externalSessionId}</span>
+                </p>
                 <p>Started: {formatTimestamp(summary.startedAt ?? trace.startedAt)}</p>
-                <p>Completed: {summary.completedAt ? formatTimestamp(summary.completedAt) : "running"}</p>
+                <p>
+                  Completed:{' '}
+                  {summary.completedAt ? formatTimestamp(summary.completedAt) : 'running'}
+                </p>
               </div>
             </div>
           </CardHeader>
@@ -122,10 +140,15 @@ export default async function TracePage({
                 <TabsContent value="events" className="pt-4">
                   <div className="space-y-4">
                     {trace.events.map((event) => (
-                      <div key={event.id} className="rounded-xl border border-slate-800 bg-slate-900/60 p-4">
+                      <div
+                        key={event.id}
+                        className="rounded-xl border border-slate-800 bg-slate-900/60 p-4"
+                      >
                         <div className="flex items-center justify-between gap-4">
                           <div className="font-medium">{event.type}</div>
-                          <div className="text-xs text-slate-500">{event.timestamp.toISOString()}</div>
+                          <div className="text-xs text-slate-500">
+                            {formatTimestamp(event.timestamp)}
+                          </div>
                         </div>
                         <Separator className="my-3" />
                         <pre className="overflow-x-auto text-xs text-slate-300">
@@ -140,7 +163,10 @@ export default async function TracePage({
                   {trace.violations.length ? (
                     <div className="space-y-3">
                       {trace.violations.map((violation) => (
-                        <div key={violation.id} className="rounded-xl border border-slate-800 bg-slate-900/60 p-4">
+                        <div
+                          key={violation.id}
+                          className="rounded-xl border border-slate-800 bg-slate-900/60 p-4"
+                        >
                           <div className="flex items-center gap-2">
                             <Badge>{violation.category}</Badge>
                             <span className="text-sm text-slate-400">{violation.eventType}</span>
@@ -165,7 +191,10 @@ export default async function TracePage({
               <CardContent className="space-y-3 text-sm text-slate-300">
                 {flattenedSpans.length ? (
                   flattenedSpans.map((span) => (
-                    <div key={span.externalSpanId} className="rounded-xl border border-slate-800 bg-slate-900/60 p-3">
+                    <div
+                      key={span.externalSpanId}
+                      className="rounded-xl border border-slate-800 bg-slate-900/60 p-3"
+                    >
                       <div className="flex items-center justify-between gap-4">
                         <div style={{ paddingLeft: `${span.depth * 14}px` }}>
                           <p className="font-medium">{span.name}</p>
@@ -203,7 +232,7 @@ export default async function TracePage({
               </CardHeader>
               <CardContent>
                 <pre className="overflow-x-auto rounded-xl border border-slate-800 bg-slate-900 p-4 text-sm">
-                  {trace.promptPayload?.contentRedacted ?? "No prompt payload"}
+                  {trace.promptPayload?.contentRedacted ?? 'No prompt payload'}
                 </pre>
               </CardContent>
             </Card>
@@ -214,7 +243,7 @@ export default async function TracePage({
               </CardHeader>
               <CardContent>
                 <pre className="overflow-x-auto rounded-xl border border-slate-800 bg-slate-900 p-4 text-sm">
-                  {trace.responsePayload?.contentRedacted ?? "No response payload"}
+                  {trace.responsePayload?.contentRedacted ?? 'No response payload'}
                 </pre>
               </CardContent>
             </Card>
@@ -222,15 +251,6 @@ export default async function TracePage({
         </div>
       </div>
     </AppShell>
-  );
-}
-
-function MetricCard({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="rounded-xl border border-slate-800 bg-slate-900/60 p-4">
-      <p className="text-sm text-slate-400">{label}</p>
-      <p className="text-xl font-semibold">{value}</p>
-    </div>
   );
 }
 
@@ -254,7 +274,7 @@ function TraceTreeNode({ node }: { node: TraceSpanNode }) {
           </div>
           <div className="text-right text-xs text-slate-400">
             {node.attributes.model ? <p>Model: {String(node.attributes.model)}</p> : null}
-            {typeof node.attributes.costUsd === "number" ? (
+            {typeof node.attributes.costUsd === 'number' ? (
               <p>Cost: {formatUsd(node.attributes.costUsd)}</p>
             ) : null}
             {node.attributes.toolName ? <p>Tool: {String(node.attributes.toolName)}</p> : null}
@@ -277,9 +297,7 @@ function TraceTimelineRow({
   timelineWindowMs: number;
 }) {
   const left = (item.offsetMs / timelineWindowMs) * 100;
-  const width = item.durationMs
-    ? Math.max((item.durationMs / timelineWindowMs) * 100, 6)
-    : 8;
+  const width = item.durationMs ? Math.max((item.durationMs / timelineWindowMs) * 100, 6) : 8;
 
   return (
     <div className="grid gap-2 md:grid-cols-[220px_minmax(0,1fr)] md:items-center">
@@ -291,7 +309,7 @@ function TraceTimelineRow({
       </div>
       <div className="relative h-12 rounded-xl border border-slate-800 bg-slate-950">
         <div
-          className={`absolute top-2 h-8 rounded-lg ${statusBarClass(item.status)}`}
+          className={cn('absolute top-2 h-8 rounded-lg', statusBarClass(item.status))}
           style={{
             left: `${Math.min(left, 92)}%`,
             width: `${Math.min(width, 100 - Math.min(left, 92))}%`,
@@ -304,14 +322,14 @@ function TraceTimelineRow({
 
 function statusBarClass(status: string) {
   switch (status) {
-    case "FAILED":
-      return "bg-rose-500/80";
-    case "BLOCKED":
-      return "bg-amber-500/80";
-    case "COMPLETED":
-      return "bg-cyan-500/80";
+    case 'FAILED':
+      return 'bg-rose-500/80';
+    case 'BLOCKED':
+      return 'bg-amber-500/80';
+    case 'COMPLETED':
+      return 'bg-cyan-500/80';
     default:
-      return "bg-slate-500/80";
+      return 'bg-slate-500/80';
   }
 }
 
@@ -319,13 +337,9 @@ function formatUsd(value: number) {
   return `$${value.toFixed(4)}`;
 }
 
-function formatTimestamp(value: Date) {
-  return value.toISOString();
-}
-
 function formatDuration(value?: number) {
-  if (typeof value !== "number") {
-    return "running";
+  if (typeof value !== 'number') {
+    return 'running';
   }
   if (value < 1000) {
     return `${value}ms`;
@@ -343,15 +357,12 @@ function datasetExportDisabledReason(trace: {
     contentRedacted?: string | null;
   } | null;
 }) {
-  const prompt =
-    trace.promptPayload?.contentRedacted ?? trace.promptPayload?.contentRaw ?? null;
+  const prompt = trace.promptPayload?.contentRedacted ?? trace.promptPayload?.contentRaw ?? null;
   const response =
-    trace.responsePayload?.contentRedacted ??
-    trace.responsePayload?.contentRaw ??
-    null;
+    trace.responsePayload?.contentRedacted ?? trace.responsePayload?.contentRaw ?? null;
 
   if (prompt == null && response == null) {
-    return "No retained prompt or response payload is available for this trace.";
+    return 'No retained prompt or response payload is available for this trace.';
   }
 
   return undefined;

--- a/apps/platform/components/app-shell.tsx
+++ b/apps/platform/components/app-shell.tsx
@@ -1,14 +1,13 @@
-import Link from "next/link";
-import { FolderKanban, PlugZap, ShieldCheck, Waypoints } from "lucide-react";
+import Link from 'next/link';
+import { FolderKanban, PlugZap, ShieldCheck, Waypoints } from 'lucide-react';
 
-import type { ReactNode } from "react";
+import type { ReactNode } from 'react';
 
-import { signOut } from "../auth";
-import { Button } from "./ui/button";
+import { signOut } from '../auth';
+import { appGradient } from '../lib/utils';
+import { Button } from './ui/button';
 
-const navItems = [
-  { href: "/projects", label: "Projects", icon: FolderKanban },
-];
+const navItems = [{ href: '/projects', label: 'Projects', icon: FolderKanban }];
 
 export function AppShell({
   userName,
@@ -18,7 +17,7 @@ export function AppShell({
   children: ReactNode;
 }) {
   return (
-    <div className="min-h-screen bg-[radial-gradient(circle_at_top_left,_rgba(34,211,238,0.12),_transparent_30%),linear-gradient(180deg,_#020617_0%,_#0f172a_100%)] text-slate-100">
+    <div className={`min-h-screen ${appGradient} text-slate-100`}>
       <header className="sticky top-0 z-40 border-b border-slate-800/80 bg-slate-950/80 backdrop-blur">
         <div className="mx-auto flex max-w-7xl items-center justify-between px-6 py-4">
           <div className="flex items-center gap-3">
@@ -32,12 +31,12 @@ export function AppShell({
           </div>
           <form
             action={async () => {
-              "use server";
-              await signOut({ redirectTo: "/login" });
+              'use server';
+              await signOut({ redirectTo: '/login' });
             }}
             className="flex items-center gap-3"
           >
-            <span className="text-sm text-slate-400">{userName ?? "Signed in"}</span>
+            <span className="text-sm text-slate-400">{userName ?? 'Signed in'}</span>
             <Button variant="secondary" size="sm" type="submit">
               Sign out
             </Button>
@@ -66,7 +65,8 @@ export function AppShell({
               <ShieldCheck className="h-4 w-4 text-cyan-300" />
               Hook policies
             </div>
-            Sync policy, ingest traces, and inspect spend, models, payloads, and violations per hook.
+            Sync policy, ingest traces, and inspect spend, models, payloads, and violations per
+            hook.
           </div>
           <div className="rounded-2xl border border-slate-800 bg-slate-950/70 p-4 text-sm text-slate-400">
             <div className="mb-3 flex items-center gap-2 text-slate-200">

--- a/apps/platform/components/manual-eval-run-reviewer.tsx
+++ b/apps/platform/components/manual-eval-run-reviewer.tsx
@@ -1,23 +1,26 @@
-"use client";
+'use client';
 
-import Link from "next/link";
-import { useEffect, useState, useTransition } from "react";
+import Link from 'next/link';
+import { useEffect, useState, useTransition } from 'react';
 
-import type { JsonValue, ManualEval, ManualEvalRun, ManualEvalVerdict } from "@captar/types";
+import type { ManualEval, ManualEvalRun, ManualEvalVerdict } from '@captar/types';
 
 import {
   calculateManualEvalDraftScore,
   getNextPendingManualEvalItemId,
-} from "../lib/manual-eval-run-workspace";
-import { Badge } from "./ui/badge";
-import { Button } from "./ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "./ui/card";
-import { Label } from "./ui/label";
-import { Textarea } from "./ui/textarea";
+} from '../lib/manual-eval-run-workspace';
+import { formatTimestamp } from '../lib/utils';
+import { MetricCard } from './metric-card';
+import { PayloadCard } from './payload-card';
+import { Badge } from './ui/badge';
+import { Button } from './ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from './ui/card';
+import { Label } from './ui/label';
+import { Textarea } from './ui/textarea';
 
 const scoreOptions = [1, 2, 3, 4, 5];
 const selectClassName =
-  "flex h-10 w-full rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300";
+  'flex h-10 w-full rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300';
 
 export function ManualEvalRunReviewer({
   projectId,
@@ -29,9 +32,9 @@ export function ManualEvalRunReviewer({
   initialRun: ManualEvalRun;
 }) {
   const [run, setRun] = useState(initialRun);
-  const [selectedItemId, setSelectedItemId] = useState(initialRun.items[0]?.id ?? "");
-  const [verdict, setVerdict] = useState<ManualEvalVerdict | "">("");
-  const [notes, setNotes] = useState("");
+  const [selectedItemId, setSelectedItemId] = useState(initialRun.items[0]?.id ?? '');
+  const [verdict, setVerdict] = useState<ManualEvalVerdict | ''>('');
+  const [notes, setNotes] = useState('');
   const [criterionScores, setCriterionScores] = useState<Record<string, string>>({});
   const [error, setError] = useState<string | null>(null);
   const [message, setMessage] = useState<string | null>(null);
@@ -39,7 +42,7 @@ export function ManualEvalRunReviewer({
 
   const selectedIndex = Math.max(
     run.items.findIndex((item) => item.id === selectedItemId),
-    0,
+    0
   );
   const currentItem = run.items[selectedIndex];
 
@@ -48,19 +51,18 @@ export function ManualEvalRunReviewer({
       return;
     }
 
-    setVerdict(currentItem.verdict ?? "");
-    setNotes(currentItem.notes ?? "");
+    setVerdict(currentItem.verdict ?? '');
+    setNotes(currentItem.notes ?? '');
     setCriterionScores(
       Object.fromEntries(
         manualEval.criteria.map((criterion) => [
           criterion.id,
           String(
-            currentItem.criterionScores.find(
-              (entry) => entry.criterionId === criterion.id,
-            )?.score ?? "",
+            currentItem.criterionScores.find((entry) => entry.criterionId === criterion.id)
+              ?.score ?? ''
           ),
-        ]),
-      ),
+        ])
+      )
     );
   }, [currentItem, manualEval.criteria]);
 
@@ -79,19 +81,17 @@ export function ManualEvalRunReviewer({
 
   const parsedScores = manualEval.criteria
     .map((criterion) => {
-      const rawValue = criterionScores[criterion.id] ?? "";
+      const rawValue = criterionScores[criterion.id] ?? '';
       const score = Number.parseInt(rawValue, 10);
 
-      return Number.isInteger(score)
-        ? { criterionId: criterion.id, score }
-        : null;
+      return Number.isInteger(score) ? { criterionId: criterion.id, score } : null;
     })
     .filter((entry): entry is { criterionId: string; score: number } => Boolean(entry));
 
   const canSave = Boolean(verdict) && parsedScores.length === manualEval.criteria.length;
   const scorePreview = calculateManualEvalDraftScore(
     manualEval.criteria,
-    Object.fromEntries(parsedScores.map((entry) => [entry.criterionId, entry.score])),
+    Object.fromEntries(parsedScores.map((entry) => [entry.criterionId, entry.score]))
   );
 
   return (
@@ -113,7 +113,7 @@ export function ManualEvalRunReviewer({
               value={
                 run.metrics.overallAverageScore != null
                   ? run.metrics.overallAverageScore.toFixed(3)
-                  : "n/a"
+                  : 'n/a'
               }
             />
           </CardContent>
@@ -130,8 +130,8 @@ export function ManualEvalRunReviewer({
                 key={item.id}
                 className={`w-full rounded-xl border p-3 text-left transition ${
                   item.id === currentItem.id
-                    ? "border-cyan-400/40 bg-cyan-400/10"
-                    : "border-slate-800 bg-slate-900/60 hover:border-slate-700"
+                    ? 'border-cyan-400/40 bg-cyan-400/10'
+                    : 'border-slate-800 bg-slate-900/60 hover:border-slate-700'
                 }`}
                 onClick={() => {
                   setError(null);
@@ -144,12 +144,12 @@ export function ManualEvalRunReviewer({
                   <div>
                     <p className="font-medium text-slate-100">Row {item.position}</p>
                     <p className="text-xs text-slate-400">
-                      {item.row.source?.kind === "trace_export"
-                        ? item.row.source.externalTraceId ?? item.row.source.traceId
-                        : "Imported row"}
+                      {item.row.source?.kind === 'trace_export'
+                        ? (item.row.source.externalTraceId ?? item.row.source.traceId)
+                        : 'Imported row'}
                     </p>
                   </div>
-                  <Badge>{item.verdict ?? "pending"}</Badge>
+                  <Badge>{item.verdict ?? 'pending'}</Badge>
                 </div>
               </button>
             ))}
@@ -163,10 +163,10 @@ export function ManualEvalRunReviewer({
             <div className="space-y-2">
               <div className="flex items-center gap-2">
                 <CardTitle>Row {currentItem.position}</CardTitle>
-                <Badge>{currentItem.verdict ?? "pending"}</Badge>
+                <Badge>{currentItem.verdict ?? 'pending'}</Badge>
               </div>
               <CardDescription>
-                Dataset row {currentItem.row.position} in manual eval{" "}
+                Dataset row {currentItem.row.position} in manual eval{' '}
                 <span className="font-medium text-slate-200">{manualEval.name}</span>
               </CardDescription>
             </div>
@@ -175,7 +175,9 @@ export function ManualEvalRunReviewer({
                 type="button"
                 variant="outline"
                 disabled={selectedIndex <= 0}
-                onClick={() => setSelectedItemId(run.items[selectedIndex - 1]?.id ?? currentItem.id)}
+                onClick={() =>
+                  setSelectedItemId(run.items[selectedIndex - 1]?.id ?? currentItem.id)
+                }
               >
                 Previous
               </Button>
@@ -183,22 +185,24 @@ export function ManualEvalRunReviewer({
                 type="button"
                 variant="outline"
                 disabled={selectedIndex >= run.items.length - 1}
-                onClick={() => setSelectedItemId(run.items[selectedIndex + 1]?.id ?? currentItem.id)}
+                onClick={() =>
+                  setSelectedItemId(run.items[selectedIndex + 1]?.id ?? currentItem.id)
+                }
               >
                 Next
               </Button>
             </div>
           </CardHeader>
           <CardContent className="grid gap-4 md:grid-cols-2">
-            <PayloadCard title="Input" value={currentItem.row.input} />
-            <PayloadCard title="Output" value={currentItem.row.output ?? null} emptyLabel="No output" />
-            <PayloadCard title="Metadata" value={currentItem.row.metadata ?? null} emptyLabel="No metadata" />
+            <PayloadCard label="Input" data={currentItem.row.input} />
+            <PayloadCard label="Output" data={currentItem.row.output ?? null} />
+            <PayloadCard label="Metadata" data={currentItem.row.metadata ?? null} />
             <Card className="border-slate-800 bg-slate-900/60">
               <CardHeader>
                 <CardTitle className="text-base">Source</CardTitle>
               </CardHeader>
               <CardContent className="space-y-3 text-sm text-slate-300">
-                <Badge>{currentItem.row.source?.kind ?? "file_import"}</Badge>
+                <Badge>{currentItem.row.source?.kind ?? 'file_import'}</Badge>
                 {currentItem.row.source?.traceId ? (
                   <Link
                     className="block text-cyan-300 hover:text-cyan-200"
@@ -209,8 +213,8 @@ export function ManualEvalRunReviewer({
                 ) : (
                   <p>Imported from a dataset file.</p>
                 )}
-                <p>Input retention: {currentItem.row.source?.inputRetentionMode ?? "n/a"}</p>
-                <p>Output retention: {currentItem.row.source?.outputRetentionMode ?? "n/a"}</p>
+                <p>Input retention: {currentItem.row.source?.inputRetentionMode ?? 'n/a'}</p>
+                <p>Output retention: {currentItem.row.source?.outputRetentionMode ?? 'n/a'}</p>
               </CardContent>
             </Card>
           </CardContent>
@@ -235,15 +239,15 @@ export function ManualEvalRunReviewer({
               <div className="flex flex-wrap gap-3">
                 <Button
                   type="button"
-                  variant={verdict === "pass" ? "default" : "outline"}
-                  onClick={() => setVerdict("pass")}
+                  variant={verdict === 'pass' ? 'default' : 'outline'}
+                  onClick={() => setVerdict('pass')}
                 >
                   Pass
                 </Button>
                 <Button
                   type="button"
-                  variant={verdict === "fail" ? "default" : "outline"}
-                  onClick={() => setVerdict("fail")}
+                  variant={verdict === 'fail' ? 'default' : 'outline'}
+                  onClick={() => setVerdict('fail')}
                 >
                   Fail
                 </Button>
@@ -266,7 +270,7 @@ export function ManualEvalRunReviewer({
                     ) : null}
                     <select
                       className={selectClassName}
-                      value={criterionScores[criterion.id] ?? ""}
+                      value={criterionScores[criterion.id] ?? ''}
                       onChange={(event) =>
                         setCriterionScores((current) => ({
                           ...current,
@@ -298,14 +302,14 @@ export function ManualEvalRunReviewer({
 
             <div className="rounded-xl border border-slate-800 bg-slate-900/60 p-4 text-sm text-slate-300">
               <p>
-                Score preview:{" "}
+                Score preview:{' '}
                 <span className="font-medium text-slate-100">
-                  {scorePreview != null ? scorePreview.toFixed(3) : "n/a"}
+                  {scorePreview != null ? scorePreview.toFixed(3) : 'n/a'}
                 </span>
               </p>
               {currentItem.reviewedAt ? (
                 <p className="mt-2 text-slate-400">
-                  Last reviewed at {new Date(currentItem.reviewedAt).toISOString()}
+                  Last reviewed at {formatTimestamp(currentItem.reviewedAt)}
                 </p>
               ) : null}
             </div>
@@ -323,21 +327,21 @@ export function ManualEvalRunReviewer({
                   const response = await fetch(
                     `/api/projects/${projectId}/evals/${manualEval.id}/runs/${run.id}/items/${currentItem.id}`,
                     {
-                      method: "PUT",
-                      headers: { "content-type": "application/json" },
+                      method: 'PUT',
+                      headers: { 'content-type': 'application/json' },
                       body: JSON.stringify({
                         verdict,
                         notes,
                         criterionScores: parsedScores,
                       }),
-                    },
+                    }
                   );
 
                   if (!response.ok) {
-                    const payload = (await response.json().catch(() => null)) as
-                      | { error?: string }
-                      | null;
-                    setError(payload?.error ?? "Could not save row review.");
+                    const payload = (await response.json().catch(() => null)) as {
+                      error?: string;
+                    } | null;
+                    setError(payload?.error ?? 'Could not save row review.');
                     return;
                   }
 
@@ -345,54 +349,18 @@ export function ManualEvalRunReviewer({
                     run: ManualEvalRun;
                   };
                   setRun(payload.run);
-                  setMessage("Saved row review.");
+                  setMessage('Saved row review.');
                   setSelectedItemId(
-                    getNextPendingManualEvalItemId(payload.run.items, currentItem.id),
+                    getNextPendingManualEvalItemId(payload.run.items, currentItem.id)
                   );
                 });
               }}
             >
-              {isPending ? "Saving..." : "Save review"}
+              {isPending ? 'Saving...' : 'Save review'}
             </Button>
           </CardContent>
         </Card>
       </div>
     </div>
-  );
-}
-
-function MetricCard({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="rounded-xl border border-slate-800 bg-slate-900/60 p-4">
-      <p className="text-sm text-slate-400">{label}</p>
-      <p className="text-lg font-semibold">{value}</p>
-    </div>
-  );
-}
-
-function PayloadCard({
-  title,
-  value,
-  emptyLabel = "No value",
-}: {
-  title: string;
-  value: JsonValue | null;
-  emptyLabel?: string;
-}) {
-  return (
-    <Card className="border-slate-800 bg-slate-900/60">
-      <CardHeader>
-        <CardTitle className="text-base">{title}</CardTitle>
-      </CardHeader>
-      <CardContent>
-        {value == null ? (
-          <p className="text-sm text-slate-500">{emptyLabel}</p>
-        ) : (
-          <pre className="overflow-x-auto whitespace-pre-wrap rounded-lg border border-slate-800 bg-slate-950 p-3 text-xs text-slate-200">
-            {typeof value === "string" ? value : JSON.stringify(value, null, 2)}
-          </pre>
-        )}
-      </CardContent>
-    </Card>
   );
 }

--- a/apps/platform/components/metric-card.tsx
+++ b/apps/platform/components/metric-card.tsx
@@ -1,0 +1,16 @@
+import { cn } from '../lib/utils';
+
+interface MetricCardProps {
+  label: string;
+  value: string | number;
+  className?: string;
+}
+
+export function MetricCard({ label, value, className }: MetricCardProps) {
+  return (
+    <div className={cn('rounded-lg border border-slate-800 bg-slate-950 p-4', className)}>
+      <p className="text-sm text-slate-400">{label}</p>
+      <p className="text-xl font-semibold text-slate-100">{value}</p>
+    </div>
+  );
+}

--- a/apps/platform/components/payload-card.tsx
+++ b/apps/platform/components/payload-card.tsx
@@ -1,0 +1,26 @@
+import { cn } from '../lib/utils';
+
+interface PayloadCardProps {
+  label: string;
+  data: unknown;
+  className?: string;
+}
+
+export function PayloadCard({ label, data, className }: PayloadCardProps) {
+  if (data === null || data === undefined) {
+    return (
+      <div className={cn('space-y-1', className)}>
+        <p className="text-xs font-medium text-slate-500">{label}</p>
+        <p className="text-sm text-slate-600">—</p>
+      </div>
+    );
+  }
+  return (
+    <div className={cn('space-y-1', className)}>
+      <p className="text-xs font-medium text-slate-500">{label}</p>
+      <pre className="max-h-64 overflow-auto rounded-md bg-slate-900 p-3 text-xs text-slate-300">
+        {JSON.stringify(data, null, 2)}
+      </pre>
+    </div>
+  );
+}

--- a/apps/platform/lib/utils.ts
+++ b/apps/platform/lib/utils.ts
@@ -1,14 +1,22 @@
-import { clsx, type ClassValue } from "clsx";
-import { twMerge } from "tailwind-merge";
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
+export function formatTimestamp(value: string | Date): string {
+  const date = typeof value === 'string' ? new Date(value) : value;
+  return date.toLocaleString();
+}
+
+export const appGradient =
+  'bg-[radial-gradient(circle_at_top_left,_rgba(34,211,238,0.12),_transparent_30%),linear-gradient(180deg,_#020617_0%,_#0f172a_100%)]';
+
 export function slugify(value: string) {
   return value
     .toLowerCase()
     .trim()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "");
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
 }


### PR DESCRIPTION
## Summary

- Extract `formatTimestamp` to `lib/utils` — replaces 5 inline copies across 5 files
- Create shared `MetricCard` component — replaces 4 local copies with inconsistent styling
- Create shared `PayloadCard` component — replaces `RowPayload` and local `PayloadCard`
- Unify gradient backgrounds into `appGradient` constant (was duplicated with different rgba/stop values)
- Replace `statusBarClass` string concat with `cn()` for proper Tailwind merge

Closes #56