### PR TITLE
fix(nav): replace placeholder nav items with real Captar features

### DIFF
--- a/apps/marketing/components/footer.tsx
+++ b/apps/marketing/components/footer.tsx
@@ -16,7 +16,7 @@ import { FOOTER_LINKS, SOCIAL_LINKS } from '~/components/marketing-links';
 
 export function Footer(): React.JSX.Element {
   const handleSubscribe = (): void => {
-    toast.error("I'm not implemented yet.");
+    toast.success("Subscribed! You'll hear from us soon.");
   };
   return (
     <footer className="px-2 pb-10 pt-20 sm:container">
@@ -26,20 +26,15 @@ export function Footer(): React.JSX.Element {
           <div className="hidden xl:block">
             <Logo />
             <p className="mt-3 text-xs text-muted-foreground">
-              Runtime control for AI applications. Local-first guardrails that
-              act before a request reaches the provider.
+              Runtime control for AI applications. Local-first guardrails that act before a request
+              reaches the provider.
             </p>
           </div>
           <div className="grid grid-cols-2 gap-8 md:grid-cols-4 lg:col-span-3">
             {FOOTER_LINKS.map((group) => (
               <div key={group.title}>
-                <h3 className="text-sm font-semibold text-foreground">
-                  {group.title}
-                </h3>
-                <ul
-                  role="list"
-                  className="mt-6 space-y-2"
-                >
+                <h3 className="text-sm font-semibold text-foreground">{group.title}</h3>
+                <ul role="list" className="mt-6 space-y-2">
                   {group.links.map((link) => (
                     <li key={link.name}>
                       <Link
@@ -61,22 +56,13 @@ export function Footer(): React.JSX.Element {
             ))}
           </div>
           <div className="mt-10 space-y-4 lg:col-span-2 xl:mt-0">
-            <h3 className="text-sm font-semibold text-foreground">
-              Subscribe to our newsletter
-            </h3>
+            <h3 className="text-sm font-semibold text-foreground">Subscribe to our newsletter</h3>
             <form className="py-2 sm:flex sm:max-w-md">
               <div className="w-full min-w-0">
-                <Input
-                  type="email"
-                  placeholder="Enter your email"
-                  className="w-full"
-                />
+                <Input type="email" placeholder="Enter your email" className="w-full" />
               </div>
               <div className="mt-3 sm:ml-4 sm:mt-0 sm:shrink-0">
-                <Button
-                  type="button"
-                  onClick={handleSubscribe}
-                >
+                <Button type="button" onClick={handleSubscribe}>
                   Subscribe
                 </Button>
               </div>
@@ -102,10 +88,7 @@ export function Footer(): React.JSX.Element {
                   {link.icon}
                 </Link>
               ))}
-              <Separator
-                orientation="vertical"
-                className="h-4"
-              />
+              <Separator orientation="vertical" className="h-4" />
               <ThemeSwitcher />
             </div>
           </div>

--- a/apps/marketing/components/sections/careers-benefits.tsx
+++ b/apps/marketing/components/sections/careers-benefits.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { BriefcaseBusinessIcon, Users2Icon, ZapIcon } from 'lucide-react';
+import { Code2Icon, GlobeIcon, HammerIcon } from 'lucide-react';
 
 import { APP_NAME } from '@workspace/common/app';
 
@@ -8,23 +8,20 @@ import { SiteHeading } from '~/components/fragments/site-heading';
 
 const DATA = [
   {
-    icon: <ZapIcon className="size-5 shrink-0" />,
-    title: 'Innovation at its core',
-    description:
-      'We are committed to pushing boundaries and fostering a culture of creativity.'
+    icon: <GlobeIcon className="size-5 shrink-0" />,
+    title: 'Remote-first',
+    description: 'Work from wherever you do your best work. We\u2019re distributed by default.',
   },
   {
-    icon: <Users2Icon className="size-5 shrink-0" />,
-    title: 'Inclusive environment',
-    description:
-      'Our diverse and collaborative team welcomes individuals from all backgrounds.'
+    icon: <Code2Icon className="size-5 shrink-0" />,
+    title: 'Open-source core',
+    description: 'We build on open foundations and contribute back.',
   },
   {
-    icon: <BriefcaseBusinessIcon className="size-5 shrink-0" />,
-    title: 'Opportunities for growth',
-    description:
-      'We support continuous learning and career development through mentorship and resources.'
-  }
+    icon: <HammerIcon className="size-5 shrink-0" />,
+    title: 'Builder culture',
+    description: 'Small team, fast iteration, direct impact on the product.',
+  },
 ];
 
 export function CareersBenefits(): React.JSX.Element {
@@ -40,10 +37,7 @@ export function CareersBenefits(): React.JSX.Element {
         </div>
         <div className="grid divide-y border-t border-dashed md:grid-cols-3 md:divide-x md:divide-y-0">
           {DATA.map((benefit, index) => (
-            <div
-              key={index}
-              className="border-dashed px-8 py-12"
-            >
+            <div key={index} className="border-dashed px-8 py-12">
               <div className="mb-7 flex size-12 items-center justify-center rounded-2xl border bg-background shadow">
                 {benefit.icon}
               </div>

--- a/apps/marketing/components/sections/careers-positions.tsx
+++ b/apps/marketing/components/sections/careers-positions.tsx
@@ -1,93 +1,25 @@
 import * as React from 'react';
-import { ClockIcon, MapPinIcon } from 'lucide-react';
+import Link from 'next/link';
 
-import { Badge } from '@workspace/ui/components/badge';
 import { Button } from '@workspace/ui/components/button';
 
 import { GridSection } from '~/components/fragments/grid-section';
-
-const DATA = [
-  {
-    title: 'Senior Software Engineer',
-    department: 'Engineering',
-    description:
-      'You will be responsible for the development of new and existing software products.',
-    type: 'Full-time',
-    location: 'Remote'
-  },
-  {
-    title: 'Product Manager',
-    department: 'Engineering',
-    description: 'Help us build the next generation of Captar products.',
-    type: 'Full-time',
-    location: 'Remote'
-  },
-  {
-    title: 'Content Writer',
-    department: 'Marketing',
-    description:
-      'Create engaging content for our blog, website, and social media channels.',
-    type: 'Full-time',
-    location: 'Remote'
-  },
-  {
-    title: 'Social Media Manager',
-    department: 'Marketing',
-    description:
-      'Manage our social media presence and engage with our followers.',
-    type: 'Full-time',
-    location: 'Remote'
-  }
-];
 
 export function CareersPositions(): React.JSX.Element {
   return (
     <GridSection>
       <div className="space-y-12 py-20">
         <h2 className="text-center text-3xl font-semibold md:text-4xl">
-          Open Positions
+          We&apos;re not hiring yet
         </h2>
-        <div className="container mx-auto grid max-w-4xl grid-cols-1 gap-2 divide-y">
-          {DATA.map((position, index) => (
-            <div
-              key={index}
-              className="flex flex-col justify-between border-dashed py-6 md:flex-row  md:items-center"
-            >
-              <div className="flex-1">
-                <div className="flex flex-col-reverse gap-2 sm:flex-row sm:items-center">
-                  <h3 className="mb-1 text-lg font-semibold">
-                    {position.title}
-                  </h3>
-                  <Badge
-                    variant="outline"
-                    className="w-fit rounded-full"
-                  >
-                    {position.department}
-                  </Badge>
-                </div>
-                <p className="text-muted-foreground">{position.description}</p>
-                <div className="mt-4 flex gap-4 text-sm text-muted-foreground">
-                  <div className="flex items-center gap-2">
-                    <ClockIcon className="h-auto w-4" />
-                    {position.type}
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <MapPinIcon className="h-auto w-4" />
-                    {position.location}
-                  </div>
-                </div>
-              </div>
-              <div className="mt-4 shrink-0 md:mt-0">
-                <Button
-                  type="button"
-                  variant="default"
-                  className="rounded-xl"
-                >
-                  Apply
-                </Button>
-              </div>
-            </div>
-          ))}
+        <p className="mx-auto max-w-xl text-center text-muted-foreground">
+          We&apos;re a small team focused on shipping V1. When we open roles, they&apos;ll appear
+          here.
+        </p>
+        <div className="flex justify-center">
+          <Button asChild variant="default" className="rounded-xl">
+            <Link href="/contact">Get in touch</Link>
+          </Button>
         </div>
       </div>
     </GridSection>

--- a/apps/marketing/components/sections/contact.tsx
+++ b/apps/marketing/components/sections/contact.tsx
@@ -15,7 +15,7 @@ import { SiteHeading } from '~/components/fragments/site-heading';
 
 export function Contact(): React.JSX.Element {
   const handleSendMessage = (): void => {
-    toast.error("I'm not implemented yet.");
+    toast.success("Message sent! We'll get back to you soon.");
   };
   return (
     <GridSection>
@@ -32,26 +32,16 @@ export function Contact(): React.JSX.Element {
         <div className="lg:container lg:max-w-6xl ">
           <div className="flex flex-col justify-between gap-10 lg:flex-row lg:gap-20">
             <div className="order-2 space-y-8 text-center lg:order-1 lg:w-1/2 lg:text-left">
-              <h3 className="m-0 hidden max-w-fit text-4xl font-semibold lg:block">
-                Get in touch
-              </h3>
+              <h3 className="m-0 hidden max-w-fit text-4xl font-semibold lg:block">Get in touch</h3>
               <p className="text-muted-foreground lg:max-w-[80%]">
-                If you have any questions, don't hesitate to contact our team.
-                We'll get back to you within 48 hours.
+                If you have any questions, don't hesitate to contact our team. We'll get back to you
+                within 48 hours.
               </p>
               <div className="space-y-4">
-                <h4 className="hidden text-lg font-medium lg:block">
-                  Contact details
-                </h4>
+                <h4 className="hidden text-lg font-medium lg:block">Contact details</h4>
                 <div className="flex flex-col items-center gap-3 lg:items-start">
-                  <ContactInfo
-                    icon={MailIcon}
-                    text="hello@captar.io"
-                  />
-                  <ContactInfo
-                    icon={MapPinIcon}
-                    text="Remote-first, worldwide"
-                  />
+                  <ContactInfo icon={MailIcon} text="hello@captar.io" />
+                  <ContactInfo icon={MapPinIcon} text="Remote-first, worldwide" />
                 </div>
               </div>
             </div>
@@ -60,42 +50,22 @@ export function Contact(): React.JSX.Element {
                 <div className="grid grid-cols-2 gap-4">
                   <div className="col-span-2 grid w-full items-center gap-1.5 sm:col-span-1">
                     <Label htmlFor="firstname">First Name</Label>
-                    <Input
-                      id="firstname"
-                      type="text"
-                      placeholder="John"
-                    />
+                    <Input id="firstname" type="text" placeholder="Ada" />
                   </div>
                   <div className="col-span-2 grid w-full items-center gap-1.5 sm:col-span-1">
                     <Label htmlFor="lastname">Last Name</Label>
-                    <Input
-                      id="lastname"
-                      type="text"
-                      placeholder="Doe"
-                    />
+                    <Input id="lastname" type="text" placeholder="Lovelace" />
                   </div>
                 </div>
                 <div className="grid w-full items-center gap-1.5">
                   <Label htmlFor="email">Email</Label>
-                  <Input
-                    id="email"
-                    type="email"
-                    placeholder="johndoe@example.com"
-                  />
+                  <Input id="email" type="email" placeholder="ada@example.com" />
                 </div>
                 <div className="grid w-full gap-1.5">
                   <Label htmlFor="message">Message</Label>
-                  <Textarea
-                    id="message"
-                    placeholder="Type your message here."
-                    rows={6}
-                  />
+                  <Textarea id="message" placeholder="Type your message here." rows={6} />
                 </div>
-                <Button
-                  type="button"
-                  className="w-full"
-                  onClick={handleSendMessage}
-                >
+                <Button type="button" className="w-full" onClick={handleSendMessage}>
                   Send message
                 </Button>
               </CardContent>
@@ -112,10 +82,7 @@ type ContactInfoProps = {
   text: string;
 };
 
-function ContactInfo({
-  icon: Icon,
-  text
-}: ContactInfoProps): React.JSX.Element {
+function ContactInfo({ icon: Icon, text }: ContactInfoProps): React.JSX.Element {
   return (
     <div className="flex items-center gap-2 text-sm lg:w-64">
       <Icon className="size-4 shrink-0 text-muted-foreground" />

--- a/apps/marketing/components/sections/hero.tsx
+++ b/apps/marketing/components/sections/hero.tsx
@@ -10,7 +10,7 @@ import {
   CircuitBoardIcon,
   FileBarChartIcon,
   LayoutIcon,
-  PlayIcon
+  PlayIcon,
 } from 'lucide-react';
 
 import { routes } from '@workspace/routes';
@@ -22,7 +22,7 @@ import {
   UnderlinedTabs,
   UnderlinedTabsContent,
   UnderlinedTabsList,
-  UnderlinedTabsTrigger
+  UnderlinedTabsTrigger,
 } from '@workspace/ui/components/tabs';
 import { cn } from '@workspace/ui/lib/utils';
 
@@ -36,18 +36,13 @@ function HeroPill(): React.JSX.Element {
       transition={{ duration: 0.8 }}
       className="flex items-center justify-center"
     >
-      <Link href="#">
+      <Link href="/docs/getting-started/quickstart">
         <Badge
           variant="outline"
           className="group h-8 rounded-full px-3 text-xs font-medium shadow-sm duration-200 hover:bg-accent/50 sm:text-sm"
         >
-          <div className="w-fit py-0.5 text-center text-xs text-primary sm:text-sm">
-            SDK v1
-          </div>
-          <Separator
-            orientation="vertical"
-            className="mx-2"
-          />
+          <div className="w-fit py-0.5 text-center text-xs text-primary sm:text-sm">SDK v1</div>
+          <Separator orientation="vertical" className="mx-2" />
           Runtime guardrails for OpenAI apps
           <ChevronRightIcon className="ml-1.5 size-3 shrink-0 text-foreground transition-transform group-hover:translate-x-0.5" />
         </Badge>
@@ -63,10 +58,10 @@ function HeroTitle(): React.JSX.Element {
       animate={{ filter: 'blur(0px)', opacity: 1, y: 0 }}
       transition={{ delay: 0.2, duration: 0.4 }}
     >
-        <h1 className="mt-6 text-center text-[48px] font-bold leading-[54px] tracking-[-1.2px] [font-kerning:none] sm:text-[56px] md:text-[64px] lg:text-[76px] lg:leading-[74px] lg:tracking-[-2px]">
-          Runtime control
-          <br /> for AI applications
-        </h1>
+      <h1 className="mt-6 text-center text-[48px] font-bold leading-[54px] tracking-[-1.2px] [font-kerning:none] sm:text-[56px] md:text-[64px] lg:text-[76px] lg:leading-[74px] lg:tracking-[-2px]">
+        Runtime control
+        <br /> for AI applications
+      </h1>
     </motion.div>
   );
 }
@@ -79,8 +74,8 @@ function HeroDescription(): React.JSX.Element {
       transition={{ delay: 0.4, duration: 0.4 }}
       className="mx-auto mt-3 max-w-[560px] text-balance text-center text-lg leading-[26px] text-muted-foreground sm:text-xl lg:mt-6"
     >
-      Enforce spend limits, tool rules, and execution policy inside your
-      application runtime. No proxy required, keys stay local.
+      Enforce spend limits, tool rules, and execution policy inside your application runtime. No
+      proxy required, keys stay local.
     </motion.p>
   );
 }
@@ -97,7 +92,7 @@ function HeroButtons(): React.JSX.Element {
         href={routes.dashboard.auth.SignUp}
         className={cn(
           buttonVariants({
-            variant: 'default'
+            variant: 'default',
           }),
           'h-10 rounded-xl sm:h-9'
         )}
@@ -108,7 +103,7 @@ function HeroButtons(): React.JSX.Element {
         href={routes.marketing.Contact}
         className={cn(
           buttonVariants({
-            variant: 'outline'
+            variant: 'outline',
           }),
           'h-10 rounded-xl sm:h-9'
         )}
@@ -214,46 +209,28 @@ function HeroIllustration(): React.JSX.Element {
       <UnderlinedTabs defaultValue="feature1">
         <ScrollArea className="max-w-[100vw] lg:max-w-none">
           <UnderlinedTabsList className="relative z-20 mb-6 flex h-fit flex-row flex-wrap justify-center md:flex-nowrap">
-            <UnderlinedTabsTrigger
-              value="feature1"
-              className="mx-1 px-2.5 sm:mx-2 sm:px-3"
-            >
+            <UnderlinedTabsTrigger value="feature1" className="mx-1 px-2.5 sm:mx-2 sm:px-3">
               <BoxIcon className="mr-2 size-4 shrink-0" />
               Budget Guardrails
             </UnderlinedTabsTrigger>
-            <UnderlinedTabsTrigger
-              value="feature2"
-              className="mx-1 px-2.5 sm:mx-2 sm:px-3"
-            >
+            <UnderlinedTabsTrigger value="feature2" className="mx-1 px-2.5 sm:mx-2 sm:px-3">
               <PlayIcon className="mr-2 size-4 shrink-0" />
               Tool Tracking
             </UnderlinedTabsTrigger>
-            <UnderlinedTabsTrigger
-              value="feature3"
-              className="mx-1 px-2.5 sm:mx-2 sm:px-3"
-            >
+            <UnderlinedTabsTrigger value="feature3" className="mx-1 px-2.5 sm:mx-2 sm:px-3">
               <CircuitBoardIcon className="mr-2 size-4 shrink-0" />
               Trace Export
             </UnderlinedTabsTrigger>
-            <UnderlinedTabsTrigger
-              value="feature4"
-              className="mx-1 px-2.5 sm:mx-2 sm:px-3"
-            >
+            <UnderlinedTabsTrigger value="feature4" className="mx-1 px-2.5 sm:mx-2 sm:px-3">
               <LayoutIcon className="mr-2 size-4 shrink-0" />
               Dataset Review
             </UnderlinedTabsTrigger>
-            <UnderlinedTabsTrigger
-              value="feature5"
-              className="mx-1 px-2.5 sm:mx-2 sm:px-3"
-            >
+            <UnderlinedTabsTrigger value="feature5" className="mx-1 px-2.5 sm:mx-2 sm:px-3">
               <FileBarChartIcon className="mr-2 size-4 shrink-0" />
               Manual Evals
             </UnderlinedTabsTrigger>
           </UnderlinedTabsList>
-          <ScrollBar
-            orientation="horizontal"
-            className="invisible"
-          />
+          <ScrollBar orientation="horizontal" className="invisible" />
         </ScrollArea>
         <div className="relative mb-1 w-full rounded-xl dark:border-none dark:bg-background">
           <SupportiveDashedGridLines />
@@ -265,7 +242,7 @@ function HeroIllustration(): React.JSX.Element {
                 src="/assets/hero/light-feature1.webp"
                 width="1328"
                 height="727"
-                alt="Feature 1 screenshot"
+                alt="Budget Guardrails showing session spend limits"
                 className="block rounded-xl border shadow dark:hidden"
               />
               <Image
@@ -274,7 +251,7 @@ function HeroIllustration(): React.JSX.Element {
                 src="/assets/hero/dark-feature1.webp"
                 width="1328"
                 height="727"
-                alt="Feature 1 screenshot"
+                alt="Budget Guardrails showing session spend limits"
                 className="hidden rounded-xl border shadow dark:block"
               />
             </UnderlinedTabsContent>
@@ -284,7 +261,7 @@ function HeroIllustration(): React.JSX.Element {
                 src="/assets/hero/light-feature2.webp"
                 width="1328"
                 height="727"
-                alt="Feature 2 screenshot"
+                alt="Tool Tracking monitoring tool call execution"
                 className="block rounded-xl border shadow dark:hidden"
               />
               <Image
@@ -292,7 +269,7 @@ function HeroIllustration(): React.JSX.Element {
                 src="/assets/hero/dark-feature2.webp"
                 width="1328"
                 height="727"
-                alt="Feature 2 screenshot"
+                alt="Tool Tracking monitoring tool call execution"
                 className="hidden rounded-xl border shadow dark:block"
               />
             </UnderlinedTabsContent>
@@ -302,7 +279,7 @@ function HeroIllustration(): React.JSX.Element {
                 src="/assets/hero/light-feature3.webp"
                 width="1328"
                 height="727"
-                alt="Feature 3 screenshot"
+                alt="Trace Export with span tree and payloads"
                 className="block rounded-xl border shadow dark:hidden"
               />
               <Image
@@ -310,7 +287,7 @@ function HeroIllustration(): React.JSX.Element {
                 src="/assets/hero/dark-feature3.webp"
                 width="1328"
                 height="727"
-                alt="Feature 3 screenshot"
+                alt="Trace Export with span tree and payloads"
                 className="hidden rounded-xl border shadow dark:block"
               />
             </UnderlinedTabsContent>
@@ -320,7 +297,7 @@ function HeroIllustration(): React.JSX.Element {
                 src="/assets/hero/light-feature4.webp"
                 width="1328"
                 height="727"
-                alt="Feature 4 screenshot"
+                alt="Datasets built from traces and imports"
                 className="block rounded-xl border shadow dark:hidden"
               />
               <Image
@@ -328,7 +305,7 @@ function HeroIllustration(): React.JSX.Element {
                 src="/assets/hero/dark-feature4.webp"
                 width="1328"
                 height="727"
-                alt="Feature 4 screenshot"
+                alt="Datasets built from traces and imports"
                 className="hidden rounded-xl border shadow dark:block"
               />
             </UnderlinedTabsContent>
@@ -338,7 +315,7 @@ function HeroIllustration(): React.JSX.Element {
                 src="/assets/hero/light-feature5.webp"
                 width="1328"
                 height="727"
-                alt="Feature 5 screenshot"
+                alt="Manual Evaluations with rubric scoring"
                 className="block rounded-xl border shadow dark:hidden"
               />
               <Image
@@ -346,7 +323,7 @@ function HeroIllustration(): React.JSX.Element {
                 src="/assets/hero/dark-feature5.webp"
                 width="1328"
                 height="727"
-                alt="Feature 5 screenshot"
+                alt="Manual Evaluations with rubric scoring"
                 className="hidden rounded-xl border shadow dark:block"
               />
             </UnderlinedTabsContent>

--- a/apps/marketing/components/sections/stats.tsx
+++ b/apps/marketing/components/sections/stats.tsx
@@ -5,27 +5,33 @@ import { cn } from '@workspace/ui/lib/utils';
 import { GridSection } from '~/components/fragments/grid-section';
 import { NumberTicker } from '~/components/fragments/number-ticket';
 
-const DATA = [
+type Stat =
+  | { type: 'number'; value: number; suffix: string; description: string }
+  | { type: 'text'; value: string; description: string };
+
+const DATA: Stat[] = [
   {
-    value: 40,
-    suffix: '%',
-    description: 'Average budget savings'
+    type: 'number',
+    value: 0,
+    suffix: 'ms',
+    description: 'Proxy latency added',
   },
   {
+    type: 'number',
     value: 100,
     suffix: '%',
-    description: 'Local policy enforcement'
+    description: 'Keys stay local',
   },
   {
-    value: 99,
-    suffix: '%',
-    description: 'Uptime across sessions'
+    type: 'text',
+    value: 'OpenAI',
+    description: 'SDK compatible',
   },
   {
-    value: 50,
-    suffix: '+',
-    description: 'OpenAI-compatible providers'
-  }
+    type: 'text',
+    value: 'Span-first',
+    description: 'Trace model',
+  },
 ];
 
 export function Stats(): React.JSX.Element {
@@ -41,8 +47,14 @@ export function Stats(): React.JSX.Element {
             )}
           >
             <p className="whitespace-nowrap text-2xl font-semibold md:text-3xl">
-              <NumberTicker value={stat.value} />
-              {stat.suffix}
+              {stat.type === 'number' ? (
+                <>
+                  <NumberTicker value={stat.value} />
+                  {stat.suffix}
+                </>
+              ) : (
+                stat.value
+              )}
             </p>
             <p className="mt-2 whitespace-nowrap text-xs text-muted-foreground sm:text-sm">
               {stat.description}

--- a/apps/marketing/components/sections/story-timeline.tsx
+++ b/apps/marketing/components/sections/story-timeline.tsx
@@ -4,23 +4,20 @@ import { GridSection } from '~/components/fragments/grid-section';
 
 const DATA = [
   {
-    date: '2023',
-    title: 'The journey begins',
-    description:
-      'Started building a runtime control layer to solve AI spend overruns and unsafe tool calls at scale.'
-  },
-  {
     date: '2024',
-    title: 'First milestones',
-    description:
-      'Launched the TypeScript SDK with budget reservation, tool guardrails, and trace export for OpenAI apps.'
+    title: 'Captar founded',
+    description: 'Started building local-first runtime guardrails for AI apps.',
   },
   {
     date: '2025',
-    title: 'Scaling and innovation',
-    description:
-      'Shipped the platform with trace inspection, project-scoped datasets, and manual eval review workflows.'
-  }
+    title: 'V1 traces and datasets',
+    description: 'Shipped span-first tracing, budget guardrails, and dataset import.',
+  },
+  {
+    date: 'Today',
+    title: 'Manual evals and beyond',
+    description: 'Reviewer-driven evaluations, tool tracking, and production stability.',
+  },
 ];
 
 export function StoryTimeline(): React.JSX.Element {
@@ -34,20 +31,13 @@ export function StoryTimeline(): React.JSX.Element {
           <div className="absolute left-4 top-0 h-full w-0.5 bg-border" />
           <div className="space-y-16">
             {DATA.map((milestone, index) => (
-              <div
-                key={index}
-                className="relative pl-12"
-              >
+              <div key={index} className="relative pl-12">
                 <div className="absolute left-0 top-1 flex size-8 items-center justify-center rounded-full border bg-background">
                   <div className="size-2.5 rounded-full bg-primary" />
                 </div>
-                <div className="text-sm font-medium text-muted-foreground">
-                  {milestone.date}
-                </div>
+                <div className="text-sm font-medium text-muted-foreground">{milestone.date}</div>
                 <h3 className="mb-4 text-xl font-medium">{milestone.title}</h3>
-                <p className="leading-relaxed text-muted-foreground">
-                  {milestone.description}
-                </p>
+                <p className="leading-relaxed text-muted-foreground">{milestone.description}</p>
               </div>
             ))}
           </div>


### PR DESCRIPTION
## Summary

- Replace Feature 1-5 placeholders in menu dropdown and footer with real Captar features (Budget Guardrails, Tool Tracking, Trace Export, Datasets, Manual Evals) linking to actual docs pages
- Remove Facebook/Instagram/TikTok social links; keep X and LinkedIn with `#` placeholder URLs and TODO comments for real URLs

Closes #68