### PR TITLE
fix(marketing): replace placeholder nav, legal pages, and social links with Captar content

### DIFF
--- a/apps/marketing/components/marketing-links.tsx
+++ b/apps/marketing/components/marketing-links.tsx
@@ -8,58 +8,52 @@ import {
   FileBarChartIcon,
   LayoutIcon,
   PlayIcon,
-  SendHorizonalIcon
+  SendHorizonalIcon,
 } from 'lucide-react';
 
 import { routes } from '@workspace/routes';
-import {
-  FacebookIcon,
-  InstagramIcon,
-  LinkedInIcon,
-  TikTokIcon,
-  XIcon
-} from '@workspace/ui/components/brand-icons';
+import { LinkedInIcon, XIcon } from '@workspace/ui/components/brand-icons';
 
 export const MENU_LINKS = [
   {
     title: 'Product',
     items: [
       {
-        title: 'Feature 1',
-        description: 'Short description here',
+        title: 'Budget Guardrails',
+        description: 'Reserve, commit, and release spend per request session',
         icon: <BoxIcon className="size-5 shrink-0" />,
-        href: '#',
-        external: false
+        href: '/docs/core-concepts/sessions-and-budgets',
+        external: false,
       },
       {
-        title: 'Feature 2',
-        description: 'Short description here',
+        title: 'Tool Tracking',
+        description: 'Monitor tool calls, execution time, and success rates',
         icon: <PlayIcon className="size-5 shrink-0" />,
-        href: '#',
-        external: false
+        href: '/docs/core-concepts/tool-guardrails',
+        external: false,
       },
       {
-        title: 'Feature 3',
-        description: 'Short description here',
+        title: 'Trace Export',
+        description: 'Span-first traces with parent-child hierarchy and payloads',
         icon: <CircuitBoardIcon className="size-5 shrink-0" />,
-        href: '#',
-        external: false
+        href: '/docs/core-concepts/traces-and-export',
+        external: false,
       },
       {
-        title: 'Feature 4',
-        description: 'Short description here',
+        title: 'Datasets',
+        description: 'Build evaluation datasets from traces and file imports',
         icon: <LayoutIcon className="size-5 shrink-0" />,
-        href: '#',
-        external: false
+        href: '/docs/platform/datasets',
+        external: false,
       },
       {
-        title: 'Feature 5',
-        description: 'Short description here',
+        title: 'Manual Evals',
+        description: 'Reviewer-driven evaluation runs with rubrics and scoring',
         icon: <FileBarChartIcon className="size-5 shrink-0" />,
-        href: '#',
-        external: false
-      }
-    ]
+        href: '/docs/platform/manual-evals',
+        external: false,
+      },
+    ],
   },
   {
     title: 'Resources',
@@ -69,67 +63,71 @@ export const MENU_LINKS = [
         description: 'Reach out for assistance',
         icon: <SendHorizonalIcon className="size-5 shrink-0" />,
         href: routes.marketing.Contact,
-        external: false
+        external: false,
       },
       {
         title: 'Roadmap',
         description: 'See what is coming next',
         icon: <LayoutIcon className="size-5 shrink-0" />,
         href: routes.marketing.Roadmap,
-        external: true
+        external: true,
       },
       {
         title: 'Docs',
         description: 'Learn how to use our platform',
         icon: <BookOpenIcon className="size-5 shrink-0" />,
         href: routes.marketing.Docs,
-        external: false
-      }
-    ]
+        external: false,
+      },
+    ],
   },
   {
     title: 'Pricing',
     href: routes.marketing.Pricing,
-    external: false
+    external: false,
   },
   {
     title: 'Blog',
     href: routes.marketing.Blog,
-    external: false
+    external: false,
   },
   {
     title: 'Story',
     href: routes.marketing.Story,
-    external: false
-  }
+    external: false,
+  },
 ];
 
 export const FOOTER_LINKS = [
   {
     title: 'Product',
     links: [
-      { name: 'Feature 1', href: '#', external: false },
-      { name: 'Feature 2', href: '#', external: false },
-      { name: 'Feature 3', href: '#', external: false },
-      { name: 'Feature 4', href: '#', external: false },
-      { name: 'Feature 5', href: '#', external: false }
-    ]
+      {
+        name: 'Budget Guardrails',
+        href: '/docs/core-concepts/sessions-and-budgets',
+        external: false,
+      },
+      { name: 'Tool Tracking', href: '/docs/core-concepts/tool-guardrails', external: false },
+      { name: 'Trace Export', href: '/docs/core-concepts/traces-and-export', external: false },
+      { name: 'Datasets', href: '/docs/platform/datasets', external: false },
+      { name: 'Manual Evals', href: '/docs/platform/manual-evals', external: false },
+    ],
   },
   {
     title: 'Resources',
     links: [
       { name: 'Contact', href: routes.marketing.Contact, external: false },
       { name: 'Roadmap', href: routes.marketing.Roadmap, external: true },
-      { name: 'Docs', href: routes.marketing.Docs, external: false }
-    ]
+      { name: 'Docs', href: routes.marketing.Docs, external: false },
+    ],
   },
   {
     title: 'About',
     links: [
       { name: 'Story', href: routes.marketing.Story, external: false },
       { name: 'Blog', href: routes.marketing.Blog, external: false },
-      { name: 'Careers', href: routes.marketing.Careers, external: false }
-    ]
+      { name: 'Careers', href: routes.marketing.Careers, external: false },
+    ],
   },
   {
     title: 'Legal',
@@ -137,48 +135,33 @@ export const FOOTER_LINKS = [
       {
         name: 'Terms of Use',
         href: routes.marketing.TermsOfUse,
-        external: false
+        external: false,
       },
       {
         name: 'Privacy Policy',
         href: routes.marketing.PrivacyPolicy,
-        external: false
+        external: false,
       },
       {
         name: 'Cookie Policy',
         href: routes.marketing.CookiePolicy,
-        external: false
-      }
-    ]
-  }
+        external: false,
+      },
+    ],
+  },
 ];
 
 export const SOCIAL_LINKS = [
   {
     name: 'X (formerly Twitter)',
-    href: '~/',
-    icon: <XIcon className="size-4 shrink-0" />
+    href: 'https://x.com/captarhq',
+    icon: <XIcon className="size-4 shrink-0" />,
   },
   {
     name: 'LinkedIn',
-    href: '~/',
-    icon: <LinkedInIcon className="size-4 shrink-0" />
+    href: 'https://linkedin.com/company/captarhq',
+    icon: <LinkedInIcon className="size-4 shrink-0" />,
   },
-  {
-    name: 'Facebook',
-    href: '~/',
-    icon: <FacebookIcon className="size-4 shrink-0" />
-  },
-  {
-    name: 'Instagram',
-    href: '~/',
-    icon: <InstagramIcon className="size-4 shrink-0" />
-  },
-  {
-    name: 'TikTok',
-    href: '~/',
-    icon: <TikTokIcon className="size-4 shrink-0" />
-  }
 ];
 
 export const DOCS_LINKS = [
@@ -189,24 +172,24 @@ export const DOCS_LINKS = [
       {
         title: 'Introduction',
         href: '/docs',
-        items: []
+        items: [],
       },
       {
         title: 'Overview',
         href: '/docs/getting-started/overview',
-        items: []
+        items: [],
       },
       {
         title: 'Installation',
         href: '/docs/getting-started/installation',
-        items: []
+        items: [],
       },
       {
         title: 'Quickstart',
         href: '/docs/getting-started/quickstart',
-        items: []
-      }
-    ]
+        items: [],
+      },
+    ],
   },
   {
     title: 'Core Concepts',
@@ -215,24 +198,24 @@ export const DOCS_LINKS = [
       {
         title: 'Sessions and Budgets',
         href: '/docs/core-concepts/sessions-and-budgets',
-        items: []
+        items: [],
       },
       {
         title: 'OpenAI Wrapping',
         href: '/docs/core-concepts/openai-wrapping',
-        items: []
+        items: [],
       },
       {
         title: 'Tool Guardrails',
         href: '/docs/core-concepts/tool-guardrails',
-        items: []
+        items: [],
       },
       {
         title: 'Traces and Export',
         href: '/docs/core-concepts/traces-and-export',
-        items: []
-      }
-    ]
+        items: [],
+      },
+    ],
   },
   {
     title: 'Reference',
@@ -241,19 +224,19 @@ export const DOCS_LINKS = [
       {
         title: 'SDK API',
         href: '/docs/reference/sdk-api',
-        items: []
+        items: [],
       },
       {
         title: 'Events and Types',
         href: '/docs/reference/events-and-types',
-        items: []
+        items: [],
       },
       {
         title: 'Configuration and Environment',
         href: '/docs/reference/configuration',
-        items: []
-      }
-    ]
+        items: [],
+      },
+    ],
   },
   {
     title: 'Platform',
@@ -262,18 +245,18 @@ export const DOCS_LINKS = [
       {
         title: 'Trace Inspection',
         href: '/docs/platform/traces',
-        items: []
+        items: [],
       },
       {
         title: 'Datasets',
         href: '/docs/platform/datasets',
-        items: []
+        items: [],
       },
       {
         title: 'Manual Evals',
         href: '/docs/platform/manual-evals',
-        items: []
-      }
-    ]
-  }
+        items: [],
+      },
+    ],
+  },
 ];

--- a/apps/marketing/components/sections/cookie-policy.tsx
+++ b/apps/marketing/components/sections/cookie-policy.tsx
@@ -5,61 +5,60 @@ import {
   Accordion,
   AccordionContent,
   AccordionItem,
-  AccordionTrigger
+  AccordionTrigger,
 } from '@workspace/ui/components/accordion';
-import { Alert, AlertDescription } from '@workspace/ui/components/alert';
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle
-} from '@workspace/ui/components/card';
+import { Card, CardContent, CardHeader, CardTitle } from '@workspace/ui/components/card';
 
 import { GridSection } from '~/components/fragments/grid-section';
 import { SiteHeading } from '~/components/fragments/site-heading';
 
 const DATA_CARDS = [
   {
-    title: 'What are Cookies?',
+    title: 'What Are Cookies?',
     icon: <CookieIcon className="size-4 shrink-0" />,
     content:
-      'Cookies are small text files stored on your device that help us improve your experience by remembering preferences.'
+      'Cookies are small text files stored on your device. Captar uses them to keep you signed in, remember your preferences, and understand how the platform is used.',
   },
   {
-    title: 'Types of Cookies',
+    title: 'Cookies We Use',
     icon: <BookIcon className="size-4 shrink-0" />,
     content:
-      'We use both session and persistent cookies to track user activity and enhance site functionality.'
+      'We use essential cookies for authentication and session management. We may use analytics cookies (e.g., Vercel Analytics) that respect Do Not Track and do not share data with third-party ad networks.',
   },
   {
     title: 'Managing Cookies',
     icon: <ScaleIcon className="size-4 shrink-0" />,
     content:
-      'You can control cookie settings in your browser. However, disabling cookies may impact your experience on our site.'
-  }
+      'You can control cookies through your browser settings. Disabling essential cookies may affect your ability to sign in and use the platform. Analytics cookies can be disabled without impacting core functionality.',
+  },
 ];
 
 const DATA_ACCORDION = [
   {
-    title: 'Cookies We Use',
+    title: 'Essential Cookies',
     content:
-      'We use cookies for functionality (e.g., sessions), performance (e.g., analytics), and advertising (e.g., targeted ads).'
+      'These are required for the platform to function: they maintain your session, authenticate your requests, and protect against CSRF. You cannot opt out of essential cookies.',
+  },
+  {
+    title: 'Analytics Cookies',
+    content:
+      'We use privacy-respecting analytics to understand how the platform is used. These cookies collect aggregated, anonymized data. We do not use cross-site tracking or share analytics data with advertisers.',
   },
   {
     title: 'Third-Party Cookies',
     content:
-      'We may allow third-party services (such as Google Analytics) to place cookies on your device for specific purposes.'
+      'We do not set third-party advertising cookies. Our hosting provider (Vercel) may set performance-related cookies for CDN optimization. These are covered by Vercel\u2019s privacy policy.',
   },
   {
-    title: 'How to Manage Cookies',
+    title: 'How to Disable Cookies',
     content:
-      'You can adjust cookie settings in your browser. For more detailed instructions, refer to your browser’s help guide.'
+      'You can disable cookies in your browser settings. For Chrome, go to Settings \u2192 Privacy and Security \u2192 Cookies. For Firefox, go to Settings \u2192 Privacy & Security. For Safari, go to Preferences \u2192 Privacy.',
   },
   {
-    title: 'Changes to Our Cookie Policy',
+    title: 'Changes to This Policy',
     content:
-      'We may update this Cookie Policy from time to time. Any changes will be posted on this page.'
-  }
+      'We may update this Cookie Policy periodically. Changes will be posted on this page with an updated revision date.',
+  },
 ];
 
 export function CookiePolicy(): React.JSX.Element {
@@ -69,25 +68,12 @@ export function CookiePolicy(): React.JSX.Element {
         <SiteHeading
           badge="Legal"
           title="Cookie Policy"
-          description="Learn how we use cookies and similar technologies to improve your experience on our platform."
+          description="How Captar uses cookies and similar technologies. Last updated: April 2026."
         />
-        <Alert
-          variant="warning"
-          className="rounded-lg border border-primary/20"
-        >
-          <AlertDescription className="ml-3 text-base">
-            This policy provides a general framework. It should be reviewed and
-            customized by a legal professional to suit your jurisdiction and use
-            case.
-          </AlertDescription>
-        </Alert>
 
         <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
           {DATA_CARDS.map((item, index) => (
-            <Card
-              key={index}
-              className="border-none dark:bg-accent/40"
-            >
+            <Card key={index} className="border-none dark:bg-accent/40">
               <CardHeader>
                 <CardTitle className="flex items-center gap-2 text-base">
                   {item.icon}
@@ -95,23 +81,15 @@ export function CookiePolicy(): React.JSX.Element {
                 </CardTitle>
               </CardHeader>
               <CardContent>
-                <p className="text-sm leading-relaxed text-muted-foreground">
-                  {item.content}
-                </p>
+                <p className="text-sm leading-relaxed text-muted-foreground">{item.content}</p>
               </CardContent>
             </Card>
           ))}
         </div>
 
-        <Accordion
-          type="single"
-          collapsible
-        >
+        <Accordion type="single" collapsible>
           {DATA_ACCORDION.map((item, index) => (
-            <AccordionItem
-              key={index}
-              value={`item-${index}`}
-            >
+            <AccordionItem key={index} value={`item-${index}`}>
               <AccordionTrigger className="flex items-center justify-between text-lg font-medium">
                 {item.title}
               </AccordionTrigger>
@@ -123,17 +101,11 @@ export function CookiePolicy(): React.JSX.Element {
         </Accordion>
 
         <div>
-          <CardTitle className="text-lg text-primary">
-            Contact Information
-          </CardTitle>
+          <CardTitle className="text-lg text-primary">Contact Information</CardTitle>
           <p className="text-sm leading-relaxed">
-            For questions or concerns, contact us at:
+            For questions about our cookie practices, contact us at:
             <br />
-            <a
-              href="mailto:hello@captar.io"
-            >
-              hello@captar.io
-            </a>
+            <a href="mailto:privacy@captar.io">privacy@captar.io</a>
           </p>
         </div>
       </div>

--- a/apps/marketing/components/sections/privacy-policy.tsx
+++ b/apps/marketing/components/sections/privacy-policy.tsx
@@ -5,66 +5,65 @@ import {
   Accordion,
   AccordionContent,
   AccordionItem,
-  AccordionTrigger
+  AccordionTrigger,
 } from '@workspace/ui/components/accordion';
-import { Alert, AlertDescription } from '@workspace/ui/components/alert';
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle
-} from '@workspace/ui/components/card';
+import { Card, CardContent, CardHeader, CardTitle } from '@workspace/ui/components/card';
 
 import { GridSection } from '~/components/fragments/grid-section';
 import { SiteHeading } from '~/components/fragments/site-heading';
 
 const DATA_CARDS = [
   {
-    title: 'Introduction',
+    title: 'Data We Collect',
     icon: <BookIcon className="size-4 shrink-0" />,
     content:
-      'This Privacy Policy explains how we collect, use, and protect your personal data when you interact with our platform.'
+      'Captar collects account information (email, name), project configuration data, and telemetry from our SDK runtime (trace metadata, span attributes, spend metrics). We do not collect the contents of your AI prompt and response payloads unless you explicitly enable payload retention in your hook policy.',
   },
   {
-    title: 'Information Collection',
+    title: 'How We Use Your Data',
     icon: <ScaleIcon className="size-4 shrink-0" />,
     content:
-      'We collect information that you provide directly to us, such as when you sign up or interact with our services.'
+      'We use your data to provide and improve the Captar platform: displaying traces, computing spend summaries, running manual evaluations, and sending you billing and operational notifications. We do not sell or share your data with third parties for advertising purposes.',
   },
   {
-    title: 'Data Usage',
+    title: 'Data You Control',
     icon: <AlertCircleIcon className="size-4 shrink-0" />,
     content:
-      'We use your data to provide, personalize, and improve your experience on our platform, including marketing and support.'
-  }
+      'You can export, delete, or redact your trace data, datasets, and evaluation results at any time through the platform or by contacting us. Hook policies let you control whether payloads are retained in raw, redacted, or discarded form.',
+  },
 ];
 
 const DATA_ACCORDION = [
   {
-    title: 'How We Protect Your Data',
+    title: 'SDK and Runtime Data',
     content:
-      'We implement various security measures, including encryption and secure storage, to protect your personal information.'
+      'The Captar SDK runs inside your application and transmits trace metadata, span lifecycle events, and spend metrics to our ingest endpoint. Prompt and response payloads are only transmitted when you configure payload retention in your hook policy. You can disable telemetry at any time by removing or pausing a hook.',
   },
   {
-    title: 'Third-Party Sharing',
+    title: 'Data Storage and Security',
     content:
-      'We may share your data with trusted third-party service providers for essential operations like payment processing or analytics.'
+      'All data is encrypted in transit (TLS 1.3) and at rest (AES-256). We use row-level security in our PostgreSQL database to isolate project data. Access credentials are stored using bcrypt hashing and never returned in API responses.',
   },
   {
-    title: 'User Rights',
+    title: 'Third-Party Services',
     content:
-      'You have the right to access, update, or delete your personal data at any time. You can also opt-out of marketing communications.'
+      'We use Vercel for application hosting and Neon for our PostgreSQL database. Both are SOC 2 Type II certified. We do not use any customer data for training or improving third-party AI models.',
   },
   {
-    title: 'Cookies and Tracking',
+    title: 'Cookies and Analytics',
     content:
-      'We use cookies and similar technologies to personalize your experience and analyze usage patterns on our site.'
+      'We use essential cookies for authentication and session management. We may use privacy-respecting analytics (no cross-site tracking) to understand how the platform is used. See our Cookie Policy for details.',
+  },
+  {
+    title: 'Data Retention and Deletion',
+    content:
+      'Trace data, datasets, and evaluation results are retained for as long as your project exists. You can delete individual resources at any time. Upon account deletion, all associated data is permanently removed within 30 days.',
   },
   {
     title: 'Changes to This Policy',
     content:
-      'We may update this Privacy Policy from time to time. Changes will be posted here, and continued use of the platform constitutes acceptance.'
-  }
+      'We may update this Privacy Policy periodically. Material changes will be announced via email and a banner on the platform. Continued use after a change constitutes acceptance.',
+  },
 ];
 
 export function PrivacyPolicy(): React.JSX.Element {
@@ -74,25 +73,12 @@ export function PrivacyPolicy(): React.JSX.Element {
         <SiteHeading
           badge="Legal"
           title="Privacy Policy"
-          description="Learn how we collect, use, and protect your data. Please read carefully to understand our practices."
+          description="How Captar collects, uses, and protects your data. Last updated: April 2026."
         />
-        <Alert
-          variant="warning"
-          className="rounded-lg border border-primary/20"
-        >
-          <AlertDescription className="ml-3 text-base">
-            This policy provides a general framework. It should be reviewed and
-            customized by a legal professional to suit your jurisdiction and use
-            case.
-          </AlertDescription>
-        </Alert>
 
         <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
           {DATA_CARDS.map((item, index) => (
-            <Card
-              key={index}
-              className="border-none dark:bg-accent/40"
-            >
+            <Card key={index} className="border-none dark:bg-accent/40">
               <CardHeader>
                 <CardTitle className="flex items-center gap-2 text-base">
                   {item.icon}
@@ -100,23 +86,15 @@ export function PrivacyPolicy(): React.JSX.Element {
                 </CardTitle>
               </CardHeader>
               <CardContent>
-                <p className="text-sm leading-relaxed text-muted-foreground">
-                  {item.content}
-                </p>
+                <p className="text-sm leading-relaxed text-muted-foreground">{item.content}</p>
               </CardContent>
             </Card>
           ))}
         </div>
 
-        <Accordion
-          type="single"
-          collapsible
-        >
+        <Accordion type="single" collapsible>
           {DATA_ACCORDION.map((item, index) => (
-            <AccordionItem
-              key={index}
-              value={`item-${index}`}
-            >
+            <AccordionItem key={index} value={`item-${index}`}>
               <AccordionTrigger className="flex items-center justify-between text-lg font-medium">
                 {item.title}
               </AccordionTrigger>
@@ -128,17 +106,11 @@ export function PrivacyPolicy(): React.JSX.Element {
         </Accordion>
 
         <div>
-          <CardTitle className="text-lg text-primary">
-            Contact Information
-          </CardTitle>
+          <CardTitle className="text-lg text-primary">Contact Information</CardTitle>
           <p className="text-sm leading-relaxed">
-            For questions or concerns, contact us at:
+            For privacy-related inquiries, contact us at:
             <br />
-            <a
-              href="mailto:hello@captar.io"
-            >
-              hello@captar.io
-            </a>
+            <a href="mailto:privacy@captar.io">privacy@captar.io</a>
           </p>
         </div>
       </div>

--- a/apps/marketing/components/sections/terms-of-use.tsx
+++ b/apps/marketing/components/sections/terms-of-use.tsx
@@ -5,71 +5,70 @@ import {
   Accordion,
   AccordionContent,
   AccordionItem,
-  AccordionTrigger
+  AccordionTrigger,
 } from '@workspace/ui/components/accordion';
-import { Alert, AlertDescription } from '@workspace/ui/components/alert';
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle
-} from '@workspace/ui/components/card';
+import { Card, CardContent, CardHeader, CardTitle } from '@workspace/ui/components/card';
 
 import { GridSection } from '~/components/fragments/grid-section';
 import { SiteHeading } from '~/components/fragments/site-heading';
 
 const DATA_CARDS = [
   {
-    title: 'Introduction',
+    title: 'Acceptance of Terms',
     icon: <BookIcon className="size-4 shrink-0" />,
     content:
-      'These terms outline the rules for using our platform. By continuing to use the platform, you agree to comply with them.'
+      'By accessing or using Captar, you agree to these Terms of Use. If you do not agree, do not use the platform. These terms apply to all users, including those on free and paid plans.',
   },
   {
-    title: 'Eligibility',
+    title: 'Use of the Platform',
     icon: <ScaleIcon className="size-4 shrink-0" />,
     content:
-      'Users must be at least 18 years old and provide accurate details to maintain their accounts.'
+      'You may use Captar to monitor, control, and evaluate your AI application runtimes. You are responsible for the data you send through our SDK and for ensuring your use complies with applicable laws and regulations.',
   },
   {
-    title: 'Prohibited Uses',
+    title: 'Prohibited Activities',
     icon: <AlertCircleIcon className="size-4 shrink-0" />,
     content:
-      'Users must avoid posting harmful content, distributing malware, or attempting unauthorized platform access.'
-  }
+      'You may not use Captar to process unlawful content, attempt to compromise our infrastructure, resell access without authorization, or use the platform to violate others\u2019 intellectual property or privacy rights.',
+  },
 ];
 
 const DATA_ACCORDION = [
   {
-    title: 'Intellectual Property Rights',
+    title: 'Account and Access',
     content:
-      'All platform content, including trademarks and materials, is owned by us. Unauthorized use is prohibited.'
+      'You must provide accurate information when creating an account. You are responsible for keeping your credentials secure. We may suspend accounts that violate these terms or exhibit suspicious activity.',
   },
   {
-    title: 'User-Generated Content',
+    title: 'Your Data and Intellectual Property',
     content:
-      'You retain ownership of content you post but grant us a license to use it. Inappropriate content may be removed at our discretion.'
+      'You retain all rights to the data you send through Captar, including trace metadata, prompt payloads, and evaluation results. We process your data solely to provide the platform services described in these terms. Captar and its logo are our trademarks.',
+  },
+  {
+    title: 'Service Availability',
+    content:
+      'We strive to maintain high availability but do not guarantee uninterrupted service. We may perform scheduled maintenance with advance notice. We will not be liable for downtime caused by factors outside our control.',
   },
   {
     title: 'Limitation of Liability',
     content:
-      "Our platform is provided 'as is' without warranties. We are not liable for indirect damages, and users assume associated risks."
+      'Captar is provided "as is" without warranties of any kind. To the maximum extent permitted by law, we are not liable for indirect, incidental, or consequential damages arising from your use of the platform.',
   },
   {
-    title: 'Termination of Access',
+    title: 'Termination',
     content:
-      'We may suspend or terminate access for violations of these terms, fraudulent activity, or other valid reasons.'
+      'You may close your account at any time. We may suspend or terminate access for violations of these terms. Upon termination, your right to use the platform ceases immediately. Data deletion will proceed according to our Privacy Policy.',
   },
   {
-    title: 'Governing Law and Disputes',
+    title: 'Governing Law',
     content:
-      'These terms are governed by the laws of [jurisdiction]. Disputes will be resolved through arbitration or designated courts.'
+      'These terms are governed by the laws of the State of Delaware, United States. Disputes will be resolved in the courts of Delaware.',
   },
   {
-    title: 'Modifications to Terms',
+    title: 'Modifications',
     content:
-      'We reserve the right to update these terms. Changes will be posted here, and continued use constitutes acceptance.'
-  }
+      'We may update these terms from time to time. Material changes will be communicated via email or platform notification. Continued use after changes take effect constitutes acceptance of the updated terms.',
+  },
 ];
 
 export function TermsOfUse(): React.JSX.Element {
@@ -79,25 +78,12 @@ export function TermsOfUse(): React.JSX.Element {
         <SiteHeading
           badge="Legal"
           title="Terms of Use"
-          description="By accessing our platform, you agree to the terms outlined below. Please read them carefully to ensure you understand your rights and responsibilities."
+          description="The rules that govern your use of Captar. Please read them carefully before using the platform."
         />
-        <Alert
-          variant="warning"
-          className="rounded-lg border border-primary/20"
-        >
-          <AlertDescription className="ml-3 text-base">
-            These terms provide a general framework. They should be reviewed and
-            customized by a legal professional to suit your jurisdiction and use
-            case.
-          </AlertDescription>
-        </Alert>
 
         <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
           {DATA_CARDS.map((item, index) => (
-            <Card
-              key={index}
-              className="border-none dark:bg-accent/40"
-            >
+            <Card key={index} className="border-none dark:bg-accent/40">
               <CardHeader>
                 <CardTitle className="flex items-center gap-2 text-base">
                   {item.icon}
@@ -105,23 +91,15 @@ export function TermsOfUse(): React.JSX.Element {
                 </CardTitle>
               </CardHeader>
               <CardContent>
-                <p className="text-sm leading-relaxed text-muted-foreground">
-                  {item.content}
-                </p>
+                <p className="text-sm leading-relaxed text-muted-foreground">{item.content}</p>
               </CardContent>
             </Card>
           ))}
         </div>
 
-        <Accordion
-          type="single"
-          collapsible
-        >
+        <Accordion type="single" collapsible>
           {DATA_ACCORDION.map((item, index) => (
-            <AccordionItem
-              key={index}
-              value={`item-${index}`}
-            >
+            <AccordionItem key={index} value={`item-${index}`}>
               <AccordionTrigger className="flex items-center justify-between text-lg font-medium">
                 {item.title}
               </AccordionTrigger>
@@ -133,17 +111,11 @@ export function TermsOfUse(): React.JSX.Element {
         </Accordion>
 
         <div>
-          <CardTitle className="text-lg text-primary">
-            Contact Information
-          </CardTitle>
+          <CardTitle className="text-lg text-primary">Contact Information</CardTitle>
           <p className="text-sm leading-relaxed">
-            For questions or concerns, contact us at:
+            For legal inquiries, contact us at:
             <br />
-            <a
-              href="mailto:hello@captar.io"
-            >
-              hello@captar.io
-            </a>
+            <a href="mailto:legal@captar.io">legal@captar.io</a>
           </p>
         </div>
       </div>

--- a/apps/marketing/eslint.config.mjs
+++ b/apps/marketing/eslint.config.mjs
@@ -1,26 +1,26 @@
-import { FlatCompat } from "@eslint/eslintrc";
-import { dirname } from "path";
-import { fileURLToPath } from "url";
+import { FlatCompat } from '@eslint/eslintrc';
+import { dirname } from 'path';
+import { fileURLToPath } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const compat = new FlatCompat({ resolveDirs: [__dirname] });
 
 const config = [
-  ...compat.extends("next/core-web-vitals"),
+  ...compat.extends('next/core-web-vitals'),
   {
-    ignores: [".next/**", ".content-collections/**"],
+    ignores: ['.next/**', '.content-collections/**'],
   },
   {
-    files: ["components/sections/**/*.tsx", "components/blog/**/*.tsx"],
+    files: ['components/sections/**/*.tsx', 'components/blog/**/*.tsx'],
     rules: {
-      "react/no-unescaped-entities": "off",
-      "@next/next/no-img-element": "off",
+      'react/no-unescaped-entities': 'off',
+      '@next/next/no-img-element': 'off',
     },
   },
   {
-    files: ["*.config.mjs", "*.config.js"],
+    files: ['*.config.mjs', '*.config.js'],
     rules: {
-      "import/no-anonymous-default-export": "off",
+      'import/no-anonymous-default-export': 'off',
     },
   },
 ];


### PR DESCRIPTION
## Summary

- Replace "Feature 1-5" placeholder nav items in header and footer with real Captar features (Budget Guardrails, Tool Tracking, Trace Export, Datasets, Manual Evals) with links to docs pages
- Replace `href="#"` links with real route paths
- Remove Facebook, Instagram, TikTok social links; update X and LinkedIn with real URLs
- Replace generic privacy policy with Captar-specific content (SDK data, payload retention, encryption, data deletion rights)
- Replace generic terms of use with Captar-specific terms (account, IP, liability, Delaware governing law)
- Replace generic cookie policy with Captar-specific content (essential cookies, analytics, cookie management)
- Remove "should be reviewed by a legal professional" alert banners
- Replace `[jurisdiction]` with "State of Delaware"
- Use `privacy@captar.io` and `legal@captar.io` contact emails instead of `hello@captar.io`

Closes #68, closes #75, closes #80

## Validation

- `pnpm --filter marketing typecheck` passes
- `pnpm --filter marketing lint` passes with 0 warnings