### PR TITLE
fix: update deployment URLs to captar.aurat.ai and fix client-side auth import

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,9 +205,9 @@ This project adheres to the [Contributor Covenant](CODE_OF_CONDUCT.md). By parti
 
 ## Support
 
-- Documentation: [captar.ai/docs](https://captar.ai/docs)
+- Documentation: [captar.aurat.ai/docs](https://captar.aurat.ai/docs)
 - Issues: [GitHub Issues](https://github.com/8dazo/captor/issues)
-- Contact: [captar.ai/contact](https://captar.ai/contact)
+- Contact: [captar.aurat.ai/contact](https://captar.aurat.ai/contact)
 
 ## License
 
@@ -218,7 +218,7 @@ Apache License 2.0. See [LICENSE](LICENSE) for details.
 <p align="center">
   <sub>Built with care by the Captar team.</sub>
   <br />
-  <a href="https://captar.ai">captar.ai</a> ·
+  <a href="https://captar.aurat.ai">captar.aurat.ai</a> ·
   <a href="https://github.com/8dazo/captor">GitHub</a> ·
   <a href="LICENSE">License</a>
 </p>

--- a/apps/marketing/content/authors/jane-doe.mdx
+++ b/apps/marketing/content/authors/jane-doe.mdx
@@ -1,5 +1,5 @@
 ---
 ref: jane-doe
 name: Captar Team
-avatar: https://captar.dev/logo.png
+avatar: https://captar.aurat.ai/logo.png
 ---

--- a/apps/marketing/content/authors/jon-doe.mdx
+++ b/apps/marketing/content/authors/jon-doe.mdx
@@ -1,5 +1,5 @@
 ---
 ref: jon-doe
 name: Captar Engineering
-avatar: https://captar.dev/logo.png
+avatar: https://captar.aurat.ai/logo.png
 ---

--- a/apps/platform/app/login/login-form.tsx
+++ b/apps/platform/app/login/login-form.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/navigation';
 import { Loader2 } from 'lucide-react';
 import { toast } from 'sonner';
 
-import { signIn } from '../../auth';
+import { signIn } from 'next-auth/react';
 import { Button } from '../../components/ui/button';
 import { Input } from '../../components/ui/input';
 import { Label } from '../../components/ui/label';

--- a/docs/infra/deployment.md
+++ b/docs/infra/deployment.md
@@ -7,7 +7,7 @@
 │   Marketing     │     │    Platform     │     │   PostgreSQL  │
 │  (Vercel)       │     │   (Vercel)      │     │  (Neon/       │
 │  Static/Pages   │     │  Serverless     │     │  Supabase)    │
-│  captar.ai      │     │  api.captar.ai  │     │               │
+│  captar.aurat.ai      │     │  platform.captar.aurat.ai  │     │               │
 └─────────────────┘     └────────┬────────┘     └───────────────┘
                                   │
                          ┌────────┴────────┐
@@ -98,7 +98,7 @@ npm run db:seed
 4. Add Environment Variables:
 
    ```
-   NEXT_PUBLIC_MARKETING_URL=https://captar.ai
+   NEXT_PUBLIC_MARKETING_URL=https://captar.aurat.ai
    ```
 
 5. **Deploy**
@@ -128,7 +128,7 @@ The `vercel.json` in `apps/marketing/` already has these settings:
 **Key Environment Variables:**
 
 ```bash
-NEXT_PUBLIC_MARKETING_URL=https://captar.ai
+NEXT_PUBLIC_MARKETING_URL=https://captar.aurat.ai
 ```
 
 ### Build Settings
@@ -144,7 +144,7 @@ echo '{ "tasks": { "build": { "dependsOn": ["^build"], "outputs": ["dist/**", ".
 
 ```bash
 # Add custom domain
-vercel domains add captar.ai
+vercel domains add captar.aurat.ai
 
 # Or in Vercel Domains settings
 # - A/AAAA records for apex domain
@@ -168,13 +168,13 @@ vercel domains add captar.ai
 
 4. **Required Environment Variables:**
 
-| Variable              | Description                                               | Example                 |
-| --------------------- | --------------------------------------------------------- | ----------------------- |
-| `DATABASE_URL`        | PostgreSQL connection                                     | `postgresql://...`      |
-| `AUTH_SECRET`         | NextAuth secret (generate with `openssl rand -base64 32`) | `abc123...`             |
-| `AUTH_URL`            | Your platform URL                                         | `https://api.captar.ai` |
-| `AUTH_TRUST_HOST`     | Required for Vercel                                       | `true`                  |
-| `CAPTAR_PLATFORM_URL` | Platform URL for SDK                                      | `https://api.captar.ai` |
+| Variable              | Description                                               | Example                            |
+| --------------------- | --------------------------------------------------------- | ---------------------------------- |
+| `DATABASE_URL`        | PostgreSQL connection                                     | `postgresql://...`                 |
+| `AUTH_SECRET`         | NextAuth secret (generate with `openssl rand -base64 32`) | `abc123...`                        |
+| `AUTH_URL`            | Your platform URL                                         | `https://platform.captar.aurat.ai` |
+| `AUTH_TRUST_HOST`     | Required for Vercel                                       | `true`                             |
+| `CAPTAR_PLATFORM_URL` | Platform URL for SDK                                      | `https://platform.captar.aurat.ai` |
 
 5. **Deploy**
 
@@ -206,13 +206,13 @@ The `vercel.json` in `apps/platform/` already has these settings:
 
 **Required Environment Variables:**
 
-| Variable              | Description                                               | Example                 |
-| --------------------- | --------------------------------------------------------- | ----------------------- |
-| `DATABASE_URL`        | PostgreSQL connection                                     | `postgresql://...`      |
-| `AUTH_SECRET`         | NextAuth secret (generate with `openssl rand -base64 32`) | `abc123...`             |
-| `AUTH_URL`            | Your platform URL                                         | `https://api.captar.ai` |
-| `AUTH_TRUST_HOST`     | Required for Vercel                                       | `true`                  |
-| `CAPTAR_PLATFORM_URL` | Platform URL for SDK                                      | `https://api.captar.ai` |
+| Variable              | Description                                               | Example                            |
+| --------------------- | --------------------------------------------------------- | ---------------------------------- |
+| `DATABASE_URL`        | PostgreSQL connection                                     | `postgresql://...`                 |
+| `AUTH_SECRET`         | NextAuth secret (generate with `openssl rand -base64 32`) | `abc123...`                        |
+| `AUTH_URL`            | Your platform URL                                         | `https://platform.captar.aurat.ai` |
+| `AUTH_TRUST_HOST`     | Required for Vercel                                       | `true`                             |
+| `CAPTAR_PLATFORM_URL` | Platform URL for SDK                                      | `https://platform.captar.aurat.ai` |
 
 **Optional:**
 
@@ -253,17 +253,17 @@ DATABASE_URL="postgresql://user:password@db.neon.tech/captar?sslmode=require"
 
 # Auth
 AUTH_SECRET="your-32-char-secret-here"
-AUTH_URL="https://api.captar.ai"
+AUTH_URL="https://platform.captar.aurat.ai"
 AUTH_TRUST_HOST="true"
 
 # URLs
-NEXT_PUBLIC_MARKETING_URL="https://captar.ai"
-NEXT_PUBLIC_PLATFORM_URL="https://api.captar.ai"
-CAPTAR_PLATFORM_URL="https://api.captar.ai"
-CAPTAR_CONTROL_PLANE_URL="https://api.captar.ai"
+NEXT_PUBLIC_MARKETING_URL="https://captar.aurat.ai"
+NEXT_PUBLIC_PLATFORM_URL="https://platform.captar.aurat.ai"
+CAPTAR_PLATFORM_URL="https://platform.captar.aurat.ai"
+CAPTAR_CONTROL_PLANE_URL="https://platform.captar.aurat.ai"
 
 # Ingest
-CAPTAR_INGEST_URL="https://api.captar.ai/api/ingest"
+CAPTAR_INGEST_URL="https://platform.captar.aurat.ai/api/ingest"
 CAPTAR_INGEST_API_KEY="your-api-key"
 ```
 
@@ -281,7 +281,7 @@ CAPTAR_INGEST_API_KEY="your-api-key"
 The platform app IS the backend. The ingest API lives at:
 
 ```
-POST https://api.captar.ai/api/ingest
+POST https://platform.captar.aurat.ai/api/ingest
 ```
 
 ### How it works:
@@ -396,26 +396,26 @@ Add these to GitHub Repository Settings > Secrets and variables > Actions:
 ### Marketing Site (Root Domain)
 
 ```
-captar.ai          A     76.76.21.21
-www.captar.ai      CNAME cname.vercel-dns.com
+captar.aurat.ai          A     76.76.21.21
+www.captar.aurat.ai      CNAME cname.vercel-dns.com
 ```
 
 ### Platform App (Subdomain)
 
 ```
-api.captar.ai      CNAME cname.vercel-dns.com
+platform.captar.aurat.ai      CNAME cname.vercel-dns.com
 ```
 
 ### Configure in Vercel:
 
-1. Marketing project: Settings > Domains > Add `captar.ai`
-2. Platform project: Settings > Domains > Add `api.captar.ai`
+1. Marketing project: Settings > Domains > Add `captar.aurat.ai`
+2. Platform project: Settings > Domains > Add `platform.captar.aurat.ai`
 
 ### Cross-Origin Setup
 
 ```bash
 # Marketing needs to know platform URL
-NEXT_PUBLIC_PLATFORM_URL=https://api.captar.ai
+NEXT_PUBLIC_PLATFORM_URL=https://platform.captar.aurat.ai
 
 # Platform needs to allow marketing origin
 # (handled in NextAuth config)
@@ -427,13 +427,13 @@ NEXT_PUBLIC_PLATFORM_URL=https://api.captar.ai
 
 ```bash
 # Check marketing site
-curl -s https://captar.ai | head -20
+curl -s https://captar.aurat.ai | head -20
 
 # Check platform health
-curl -s https://api.captar.ai/api/health
+curl -s https://platform.captar.aurat.ai/api/health
 
 # Test ingest endpoint
-curl -X POST https://api.captar.ai/api/ingest \
+curl -X POST https://platform.captar.aurat.ai/api/ingest \
   -H "Content-Type: application/json" \
   -d '{"events":[],"hookId":"test"}'
 
@@ -487,7 +487,7 @@ DATABASE_URL="...?sslmode=require"
 
 ```bash
 # Ensure AUTH_URL matches deployed URL exactly
-AUTH_URL=https://api.captar.ai  # NOT http://localhost:3000
+AUTH_URL=https://platform.captar.aurat.ai  # NOT http://localhost:3000
 ```
 
 ---

--- a/packages/schemas/jsonschema/event-envelope.schema.json
+++ b/packages/schemas/jsonschema/event-envelope.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://captar.dev/schemas/event-envelope.schema.json",
+  "$id": "https://captar.aurat.ai/schemas/event-envelope.schema.json",
   "title": "Captar Event Envelope",
   "type": "object",
   "required": ["id", "type", "timestamp", "sessionId", "trace", "data"],

--- a/packages/schemas/jsonschema/policy.schema.json
+++ b/packages/schemas/jsonschema/policy.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://captar.dev/schemas/policy.schema.json",
+  "$id": "https://captar.aurat.ai/schemas/policy.schema.json",
   "title": "Captar Policy",
   "type": "object",
   "properties": {


### PR DESCRIPTION
Closes #110

## Summary

Update all hardcoded deployment URLs from old domains to new live domains:
- **Marketing site**: `https://captar.aurat.ai`
- **Platform app**: `https://platform.captar.aurat.ai`

Fixes a client-side runtime error where `login-form.tsx` imported `signIn` from the server `auth.ts` file, causing `headers was called outside a request scope`.

## Changes

### URL Updates
- `README.md` — support links, footer
- `docs/infra/deployment.md` — architecture diagram, env examples, DNS records, curl commands, domain setup
- `apps/marketing/content/authors/jane-doe.mdx` — avatar URL
- `apps/marketing/content/authors/jon-doe.mdx` — avatar URL
- `packages/schemas/jsonschema/policy.schema.json` — `$id` URL
- `packages/schemas/jsonschema/event-envelope.schema.json` — `$id` URL

### Bug Fix
- `apps/platform/app/login/login-form.tsx` — changed `signIn` import from `../../auth` (server) to `next-auth/react` (client). Resolves the Next.js dynamic API wrong-context error when submitting the login form.

## Deployment Notes
After merge, ensure Vercel environment variables are updated:
- `NEXT_PUBLIC_MARKETING_URL=https://captar.aurat.ai`
- `NEXT_PUBLIC_PLATFORM_URL=https://platform.captar.aurat.ai`
- `AUTH_URL=https://platform.captar.aurat.ai`
- `CAPTAR_PLATFORM_URL=https://platform.captar.aurat.ai`