### PR TITLE
ci: install Vercel CLI before platform deploy

### DIFF
--- a/.github/workflows/deploy-platform.yml
+++ b/.github/workflows/deploy-platform.yml
@@ -22,6 +22,8 @@ jobs:
           cache: 'pnpm'
       - run: pnpm install --frozen-lockfile
       - run: pnpm db:generate
+      - name: Install Vercel CLI
+        run: pnpm add -g vercel
       - name: Trigger Vercel Deployment
         run: |
           vercel deploy --token ${{ secrets.VERCEL_TOKEN }} --yes --prod


### PR DESCRIPTION
Fixes the "Deploy Platform to Vercel" workflow failing with `vercel: command not found` on the GitHub Actions runner.